### PR TITLE
ERC721Burnable support

### DIFF
--- a/e2e/common/index.ts
+++ b/e2e/common/index.ts
@@ -292,6 +292,9 @@ export const ERC721_PRECOMPILE_ABI = [
   "function symbol() public view returns (string memory)",
   "function tokenURI(uint256 tokenId) public view returns (string memory)",
 
+  // ERC721 Burnable
+  "function burn(uint256 tokenId)",
+
   // Root specific precompiles
   "event MaxSupplyUpdated(uint32 maxSupply)",
   "event BaseURIUpdated(string baseURI)",

--- a/e2e/contracts/MockERC721.sol
+++ b/e2e/contracts/MockERC721.sol
@@ -2,9 +2,10 @@
 pragma solidity ^0.8.17;
 
 import "@openzeppelin/contracts/token/ERC721/ERC721.sol";
+import "@openzeppelin/contracts/token/ERC721/extensions/ERC721Burnable.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
 
-contract MockERC721 is ERC721, Ownable {
+contract MockERC721 is ERC721, Ownable, ERC721Burnable {
     constructor() ERC721("MyToken", "MTK") {}
 
     function safeMint(address to, uint256 tokenId) public {

--- a/e2e/test/ERC721/ERC721Precompile.test.ts
+++ b/e2e/test/ERC721/ERC721Precompile.test.ts
@@ -21,7 +21,7 @@ import {
 // NFT Collection information
 const name = "test-collection";
 const metadataPath = "https://example.com/nft/metadata/";
-const initialIssuance = 11;
+const initialIssuance = 12;
 const maxIssuance = 100;
 
 describe("ERC721 Precompile", function () {
@@ -114,7 +114,7 @@ describe("ERC721 Precompile", function () {
     cursor = 5;
     limit = 5;
     [new_cursor, total_owned, tokens] = await erc721Precompile.ownedTokens(bobSigner.address, limit, cursor);
-    expect(new_cursor).to.equal(0);
+    expect(new_cursor).to.equal(10);
     expect(total_owned).to.equal(initialIssuance);
     expect(tokens).to.eql([5, 6, 7, 8, 9]);
 
@@ -124,7 +124,7 @@ describe("ERC721 Precompile", function () {
     [new_cursor, total_owned, tokens] = await erc721Precompile.ownedTokens(bobSigner.address, limit, cursor);
     expect(new_cursor).to.equal(0);
     expect(total_owned).to.equal(initialIssuance);
-    expect(tokens).to.eql([]);
+    expect(tokens).to.eql([10, 11]);
 
     // high limit should return ALL tokens owned by bob
     cursor = 0;
@@ -132,7 +132,7 @@ describe("ERC721 Precompile", function () {
     [new_cursor, total_owned, tokens] = await erc721Precompile.ownedTokens(bobSigner.address, limit, cursor);
     expect(new_cursor).to.equal(0);
     expect(total_owned).to.equal(initialIssuance);
-    expect(tokens).to.eql([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+    expect(tokens).to.eql([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]);
   });
 
   it("mint - succeeds as owner", async () => {
@@ -596,6 +596,10 @@ describe("ERC721 Precompile", function () {
   it("burn not approved fails", async () => {
     const tokenId = 10;
 
+    // Set approval for all to false
+    const approval = await erc721Precompile.setApprovalForAll(alithSigner.address, false);
+    await approval.wait();
+
     // Sanity check
     const initial_balance = await erc721Precompile.balanceOf(bobSigner.address);
 
@@ -610,7 +614,7 @@ describe("ERC721 Precompile", function () {
   });
 
   it("burn as approved", async () => {
-    const tokenId = 10;
+    const tokenId = 11;
 
     // Sanity check
     const initial_balance = await erc721Precompile.balanceOf(bobSigner.address);
@@ -627,7 +631,8 @@ describe("ERC721 Precompile", function () {
       .withArgs(bobSigner.address, constants.AddressZero, tokenId);
 
     // balance is now one less
-    expect(await erc721Precompile.balanceOf(bobSigner.address)).to.equal(initial_balance - 1);
+    const balance_after = await erc721Precompile.balanceOf(bobSigner.address);
+    expect(balance_after).to.equal(initial_balance - 1);
   });
 
   it("owner, renounceOwnership, transferOwnership", async () => {

--- a/e2e/test/ERC721/Erc721.TxCosts.test.ts
+++ b/e2e/test/ERC721/Erc721.TxCosts.test.ts
@@ -309,7 +309,7 @@ describe("ERC721 Gas Estimates", function () {
       Extrinsic: extrinsicGasScaled,
     };
     allTxFeeCosts["burn"] = {
-      Contract: constractFeeCost.div(1000000000000n), // convert to XRP Drops(6)
+      Contract: contractFeeCost.div(1000000000000n), // convert to XRP Drops(6)
       Precompile: precompileFeeCost.div(1000000000000n), // convert to XRP Drops(6)
       Extrinsic: extrinsicFeeCost.div(1000000000000n), // convert to XRP Drops(6)
     };

--- a/e2e/test/ERC721/Erc721.TxCosts.test.ts
+++ b/e2e/test/ERC721/Erc721.TxCosts.test.ts
@@ -285,7 +285,7 @@ describe("ERC721 Gas Estimates", function () {
     tx = await erc721Contract.connect(alithSigner).burn(contractTokenId, { gasLimit: contractGasEstimate });
     await tx.wait();
     balanceAfter = await alithSigner.getBalance();
-    const constractFeeCost = balanceBefore.sub(balanceAfter);
+    const contractFeeCost = balanceBefore.sub(balanceAfter);
 
     // Extrinsic cost
     balanceBefore = await alithSigner.getBalance();

--- a/e2e/test/ERC721/TxCosts.md
+++ b/e2e/test/ERC721/TxCosts.md
@@ -2,29 +2,31 @@
 
 | Function Call     | Contract gas | Precompile gas | (Extrinsic fee/Gas price) |
 | :---------------- | :----------: | :------------: | :-----------------------: |
-| balanceOf         |    25889     |     23274      |             0             |
-| ownerOf           |    24220     |     23242      |             0             |
+| balanceOf         |    25895     |     23274      |             0             |
+| ownerOf           |    25847     |     23242      |             0             |
 | getApproved       |    27395     |     23242      |             0             |
 | isApprovedForAll  |    26082     |     23973      |             0             |
-| mint              |    51242     |     28920      |           17168           |
-| approve           |    50740     |     27771      |           23668           |
-| setApprovalForAll |    47011     |     26355      |           23168           |
-| safetransferFrom  |    61763     |     35798      |             0             |
-| transferFrom      |    61428     |     35412      |           20503           |
+| mint              |    53211     |     31937      |           17335           |
+| burn              |    37888     |     36617      |           17170           |
+| approve           |    50740     |     28914      |           23835           |
+| setApprovalForAll |    47011     |     27438      |           23335           |
+| safetransferFrom  |    67203     |     36832      |             0             |
+| transferFrom      |    66861     |     35757      |           20670           |
 | name              |    25932     |     22388      |             0             |
 | symbol            |    25938     |     22388      |             0             |
 | tokenURI          |    25964     |     23242      |             0             |
 | owner             |    23728     |     22388      |             0             |
-| transferOwnership |    27323     |     28447      |           19668           |
-| renounceOwnership |    28530     |     27834      |           19668           |
+| transferOwnership |    29147     |     28901      |           19835           |
+| renounceOwnership |    30272     |     28520      |           19835           |
 
 ## Generated tx costs(fees) for ERC721 Precompiles
 
 | Function Call     | Contract cost (Drops) | Precompile cost (Drops) | Extrinsic cost (Drops) |
 | :---------------- | :-------------------: | :---------------------: | :--------------------: |
-| mint              |        750270         |         432088          |         257531         |
-| approve           |        739543         |         414626          |         355030         |
-| setApprovalForAll |        699609         |         390669          |         347523         |
-| transferFrom      |        664701         |         524332          |         307548         |
-| transferOwnership |        394149         |         422832          |         295031         |
-| renounceOwnership |        305850         |         417491          |         295031         |
+| mint              |        792274         |         455055          |         260038         |
+| burn              |        491074         |         539618          |         257550         |
+| approve           |        739543         |         431848          |         357534         |
+| setApprovalForAll |        699609         |         399384          |         350025         |
+| transferFrom      |        884878         |         534383          |         310050         |
+| transferOwnership |        436153         |         431293          |         297533         |
+| renounceOwnership |        352310         |         425952          |         297533         |

--- a/evm-precompiles/erc721/README.md
+++ b/evm-precompiles/erc721/README.md
@@ -29,6 +29,12 @@ interface IERC721Metadata is IERC721 {
 ```
 
 ```solidity
+interface IERC721Burnable is IERC721 {
+    function burn(uint256 tokenId) external;
+}
+```
+
+```solidity
 interface TRN721 is IERC165 {
     event MaxSupplyUpdated(uint32 maxSupply);
     event BaseURIUpdated(string baseURI);


### PR DESCRIPTION
Adds ERC721 burn precompile which allows users to burn through EVM, calling the internal NFT.burn method and emitting a transfer event. 

OZ source: https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/token/ERC721/extensions/ERC721Burnable.sol