### PR TITLE
Release 4.46.0

### DIFF
--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -151,7 +151,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("root"),
 	impl_name: create_runtime_str!("root"),
 	authoring_version: 1,
-	spec_version: 45,
+	spec_version: 46,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 6,


### PR DESCRIPTION
- Bumped spec version to `46` 

[Changelog](https://github.com/futureversecom/trn-seed/issues/748)
