### PR TITLE
Add limit to number of pruned txs per block in on_idle

### DIFF
--- a/pallet/xrpl-bridge/src/mock.rs
+++ b/pallet/xrpl-bridge/src/mock.rs
@@ -51,6 +51,7 @@ parameter_types! {
 	pub const TicketSequenceThreshold: Percent = Percent::from_percent(66_u8);
 	pub const XRPTransactionLimit: u32 = 10;
 	pub const XRPLTransactionLimitPerLedger: u32 = 10;
+	pub const MaxPrunedTransactionsPerBlock: u32 = 5000;
 	pub const XrpAssetId: u32 = XRP_ASSET_ID;
 }
 
@@ -62,6 +63,7 @@ impl pallet_xrpl_bridge::Config for Test {
 	type WeightInfo = ();
 	type XrpAssetId = XrpAssetId;
 	type ChallengePeriod = XrpTxChallengePeriod;
+	type MaxPrunedTransactionsPerBlock = MaxPrunedTransactionsPerBlock;
 	type UnixTime = TimestampPallet;
 	type TicketSequenceThreshold = TicketSequenceThreshold;
 	type XRPTransactionLimit = XRPTransactionLimit;

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -573,6 +573,8 @@ parameter_types! {
 	/// NOTE - XRPTransactionLimitPerLedger should be more than or equal to XRPTransactionLimit
 	pub const XRPTransactionLimit: u32 = 1_000_000;
 	pub const XRPTransactionLimitPerLedger: u32 = 1_000_000;
+	/// NOTE - This value can't be set too high. 5000 is roughly 25% of the max block weight
+	pub const MaxPrunedTransactionsPerBlock: u32 = 5000;
 }
 
 impl pallet_xrpl_bridge::Config for Runtime {
@@ -583,6 +585,7 @@ impl pallet_xrpl_bridge::Config for Runtime {
 	type WeightInfo = weights::pallet_xrpl_bridge::WeightInfo<Runtime>;
 	type XrpAssetId = XrpAssetId;
 	type ChallengePeriod = XrpTxChallengePeriod;
+	type MaxPrunedTransactionsPerBlock = MaxPrunedTransactionsPerBlock;
 	type UnixTime = Timestamp;
 	type TicketSequenceThreshold = TicketSequenceThreshold;
 	type XRPTransactionLimit = XRPTransactionLimit;


### PR DESCRIPTION
Adds a limit of 5000 to the number of ledger indices we can clear in one block. It will still only clear as many as it can but this will prevent the settled_txs_to_clear Vec from getting too large if the gap between `HighestPrunedLedgerIndex` and `HighestSettledLedgerIndex` is too high