### PR TITLE
some improvements based on auditor's questions

### DIFF
--- a/pallet/vortex-distribution/src/benchmarking.rs
+++ b/pallet/vortex-distribution/src/benchmarking.rs
@@ -148,6 +148,9 @@ benchmarks! {
 		assert_ok!(VortexDistribution::<T>::start_vtx_dist(RawOrigin::Root.into(), vortex_dist_id));
 		System::<T>::set_block_number(end_block.into());
 		assert_ok!(VortexDistribution::<T>::pay_unsigned(RawOrigin::None.into(), vortex_dist_id, end_block.into()));
+		VtxDistStatuses::<T>::mutate(vortex_dist_id, |status| {
+			*status = VtxDistStatus::Done;
+		});
 	}: _(RawOrigin::Signed(account::<T>("test")), vortex_dist_id, balance)
 	verify {
 		assert_eq!(T::MultiCurrency::balance(T::VtxAssetId::get(), &account::<T>("test")), balance);

--- a/pallet/vortex-distribution/src/lib.rs
+++ b/pallet/vortex-distribution/src/lib.rs
@@ -334,11 +334,11 @@ pub mod pallet {
 		/// Assets should not include vortex asset
 		AssetsShouldNotIncludeVtxAsset,
 
-		/// Vortex distribution is not already to be triggered
-		NotReadyToBeTriggered,
+		/// Vortex distribution is not ready to be triggered
+		CannotTrigger,
 
-		/// Vortex distribution is not already to redeem
-		NotReadyToRedeem,
+		/// Vortex distribution is not ready to be redeemed
+		CannotRedeem,
 
 		/// Vortex distribution not triggered
 		NotTriggered,
@@ -566,7 +566,7 @@ pub mod pallet {
 
 			ensure!(
 				VtxDistStatuses::<T>::get(id.clone()) == VtxDistStatus::Enabled,
-				Error::<T>::NotReadyToBeTriggered
+				Error::<T>::CannotTrigger
 			);
 
 			Self::do_vtx_distribution_trigger(id)
@@ -595,7 +595,7 @@ pub mod pallet {
 			);
 			ensure!(
 				VtxDistStatuses::<T>::get(id.clone()) == VtxDistStatus::Done,
-				Error::<T>::NotReadyToRedeem
+				Error::<T>::CannotRedeem
 			);
 
 			for (asset_id, _) in AssetPrices::<T>::iter_prefix(id) {

--- a/pallet/vortex-distribution/src/lib.rs
+++ b/pallet/vortex-distribution/src/lib.rs
@@ -60,8 +60,8 @@ pub const VTX_DIST_UNSIGNED_PRIORITY: TransactionPriority = TransactionPriority:
 	Clone, Copy, Encode, Decode, RuntimeDebug, PartialEq, PartialOrd, Eq, TypeInfo, MaxEncodedLen,
 )]
 pub enum VtxDistStatus {
-	Enabled,
 	Disabled,
+	Enabled,
 	Triggered,
 	Paying,
 	Done,
@@ -334,8 +334,11 @@ pub mod pallet {
 		/// Assets should not include vortex asset
 		AssetsShouldNotIncludeVtxAsset,
 
-		/// Vortex distribution already triggered
-		AlreadyTriggered,
+		/// Vortex distribution is not already to be triggered
+		NotReadyToBeTriggered,
+
+		/// Vortex distribution is not already to redeem
+		NotReadyToRedeem,
 
 		/// Vortex distribution not triggered
 		NotTriggered,
@@ -412,7 +415,7 @@ pub mod pallet {
 		///
 		/// `id` - The distribution id
 		/// `current_block` - Current block number
-		#[pallet::weight(<T as pallet::Config>::WeightInfo::pay_unsigned() * 99)]
+		#[pallet::weight(<T as pallet::Config>::WeightInfo::pay_unsigned().saturating_mul(T::PayoutBatchSize::get().into()))]
 		#[transactional]
 		pub fn pay_unsigned(
 			origin: OriginFor<T>,
@@ -538,7 +541,7 @@ pub mod pallet {
 					for (who, amount) in rewards.iter() {
 						total_rewards += *amount;
 						VtxDistOrderbook::<T>::mutate(id, who.clone(), |entry| {
-							*entry = (entry.0.saturating_add(*amount), entry.1);
+							*entry = (*amount, false);
 						});
 					}
 					TotalVortex::<T>::mutate(id, |total_vortex| {
@@ -562,8 +565,8 @@ pub mod pallet {
 			Self::ensure_root_or_admin(origin)?;
 
 			ensure!(
-				VtxDistStatuses::<T>::get(id.clone()) < VtxDistStatus::Triggered,
-				Error::<T>::AlreadyTriggered
+				VtxDistStatuses::<T>::get(id.clone()) == VtxDistStatus::Enabled,
+				Error::<T>::NotReadyToBeTriggered
 			);
 
 			Self::do_vtx_distribution_trigger(id)
@@ -589,6 +592,10 @@ pub mod pallet {
 				vortex_balance > Zero::zero() &&
 					vortex_balance <= T::MultiCurrency::balance(T::VtxAssetId::get(), &who),
 				Error::<T>::InvalidAmount
+			);
+			ensure!(
+				VtxDistStatuses::<T>::get(id.clone()) == VtxDistStatus::Done,
+				Error::<T>::NotReadyToRedeem
 			);
 
 			for (asset_id, _) in AssetPrices::<T>::iter_prefix(id) {

--- a/pallet/vortex-distribution/src/tests.rs
+++ b/pallet/vortex-distribution/src/tests.rs
@@ -174,9 +174,8 @@ fn start_vtx_dist_without_root_origin_should_fail() {
 #[test]
 fn start_vtx_dist_with_already_paying_status_should_fail() {
 	TestExt::default().build().execute_with(|| {
-		assert_ok!(Vortex::create_vtx_dist(Origin::root()));
-
 		let vortex_dist_id = NextVortexId::<Test>::get();
+		assert_ok!(Vortex::create_vtx_dist(Origin::root()));
 
 		assert_ok!(Vortex::trigger_vtx_distribution(Origin::root(), vortex_dist_id));
 
@@ -656,10 +655,10 @@ fn trigger_vtx_distribution_should_work() {
 #[test]
 fn trigger_vtx_distribution_should_fail_if_already_triggered() {
 	TestExt::default().build().execute_with(|| {
-		assert_ok!(Vortex::create_vtx_dist(Origin::root()));
-
 		// Retrieve the ID of the newly created vortex distribution.
 		let vortex_dist_id = NextVortexId::<Test>::get();
+
+		assert_ok!(Vortex::create_vtx_dist(Origin::root()));
 
 		// Trigger the vortex distribution process.
 		assert_ok!(Vortex::trigger_vtx_distribution(Origin::root(), vortex_dist_id,));
@@ -667,7 +666,7 @@ fn trigger_vtx_distribution_should_fail_if_already_triggered() {
 		// Attempt to trigger the same distribution again should fail.
 		assert_noop!(
 			Vortex::trigger_vtx_distribution(Origin::root(), vortex_dist_id,),
-			Error::<Test>::AlreadyTriggered
+			Error::<Test>::NotReadyToBeTriggered
 		);
 	});
 }
@@ -780,6 +779,10 @@ fn redeem_tokens_from_vault_should_work() {
 				AssetsExt::total_issuance(<Test as crate::Config>::VtxAssetId::get()),
 				1_000_000
 			);
+
+			VtxDistStatuses::<Test>::mutate(vortex_dis_id, |status| {
+				*status = VtxDistStatus::Done;
+			});
 
 			assert_ok!(Vortex::redeem_tokens_from_vault(
 				Origin::signed(bob),

--- a/pallet/vortex-distribution/src/tests.rs
+++ b/pallet/vortex-distribution/src/tests.rs
@@ -666,7 +666,7 @@ fn trigger_vtx_distribution_should_fail_if_already_triggered() {
 		// Attempt to trigger the same distribution again should fail.
 		assert_noop!(
 			Vortex::trigger_vtx_distribution(Origin::root(), vortex_dist_id,),
-			Error::<Test>::NotReadyToBeTriggered
+			Error::<Test>::CannotTrigger
 		);
 	});
 }


### PR DESCRIPTION
Addressing the following questions from Red4Sec

### Question 1
What is the `99` meant to do here? And why is the multiplication not saturating? Guessing based on the configuration in the runtime, this should be `PayoutBatchSize`, right?
https://github.com/futureversecom/trn-seed/blob/a5fe2f7c58bf19994a7ba077c9cf47f30b76280b/pallet/vortex-distribution/src/lib.rs#L389

### Question 2
Are you sure the `Disabled` state should allow for triggering?
https://github.com/futureversecom/trn-seed/blob/a5fe2f7c58bf19994a7ba077c9cf47f30b76280b/pallet/vortex-distribution/src/lib.rs#L545
https://github.com/futureversecom/trn-seed/blob/a5fe2f7c58bf19994a7ba077c9cf47f30b76280b/pallet/vortex-distribution/src/lib.rs#L227

### Question 4
This should probably be set to `false`, not `entry.1` to ensure that it is paid out? As written, this looks like a possible logic error. You might potentially want to overwrite the amount instead of adding it together if there was already a distribution for this account.
https://github.com/futureversecom/trn-seed/blob/a5fe2f7c58bf19994a7ba077c9cf47f30b76280b/pallet/vortex-distribution/src/lib.rs#L515
https://github.com/futureversecom/trn-seed/blob/b844416f92c25dc70badeb7a4bbf6f9eab134987/pallet/vortex-distribution/src/lib.rs#L526
