### PR TITLE
Remove create fee override

### DIFF
--- a/e2e/test/EVMGasCosts.test.ts
+++ b/e2e/test/EVMGasCosts.test.ts
@@ -156,8 +156,8 @@ describe("EVM gas costs", () => {
     // assert XRP used
     const xrpCost6DP = actualCost.div(10 ** 12).toNumber();
     const xrpCostScaled = +utils.formatEther(actualCost);
-    expect(xrpCost6DP).to.eql(51008760);
-    expect(+xrpCostScaled.toFixed(6)).to.eql(51.00876);
+    expect(xrpCost6DP).to.eql(21803760);
+    expect(+xrpCostScaled.toFixed(6)).to.eql(21.80376);
   });
 
   it("gas cost for token mint", async () => {

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -31,9 +31,7 @@ use pallet_ethereum::{
 	Call::transact, InvalidTransactionWrapper, Transaction as EthereumTransaction,
 	TransactionAction,
 };
-use pallet_evm::{
-	Account as EVMAccount, EnsureAddressNever, EvmConfig, FeeCalculator, Runner as RunnerT,
-};
+use pallet_evm::{Account as EVMAccount, EnsureAddressNever, FeeCalculator, Runner as RunnerT};
 use pallet_staking::RewardDestination;
 use pallet_transaction_payment::{Multiplier, TargetedFeeAdjustment};
 use seed_pallet_common::MaintenanceCheck;
@@ -1055,15 +1053,6 @@ parameter_types! {
 	pub WeightPerGas: Weight = Weight::from_ref_time(WEIGHT_PER_GAS);
 }
 
-/// Modified london config with higher contract create fee
-const fn seed_london() -> EvmConfig {
-	let mut c = EvmConfig::london();
-	c.gas_transaction_create = 2_000_000;
-	c
-}
-
-pub static SEED_EVM_CONFIG: EvmConfig = seed_london();
-
 impl pallet_evm::Config for Runtime {
 	type FeeCalculator = FeeControl;
 	type GasWeightMapping = FutureverseGasWeightMapping;
@@ -1080,10 +1069,6 @@ impl pallet_evm::Config for Runtime {
 	type BlockGasLimit = BlockGasLimit;
 	type OnChargeTransaction = FutureverseEVMCurrencyAdapter<Self::Currency, TxFeePot>;
 	type FindAuthor = EthereumFindAuthor<Babe>;
-	// internal EVM config
-	fn config() -> &'static EvmConfig {
-		&SEED_EVM_CONFIG
-	}
 	type HandleTxValidation = HandleTxValidation<pallet_evm::Error<Runtime>>;
 	type WeightPerGas = WeightPerGas;
 }


### PR DESCRIPTION
Removes the 2,000,000 evm gas_transaction_create override in favor of the default value. This will bring the cost of creating contracts in line with other EVM compatible chains
