### PR TITLE
Fix Asset Existence Verification in ERC20 Precompile

### DIFF
--- a/pallet/assets-ext/src/lib.rs
+++ b/pallet/assets-ext/src/lib.rs
@@ -33,7 +33,7 @@ use frame_support::{
 	pallet_prelude::*,
 	traits::{
 		fungible::{self, Inspect as _, Mutate as _},
-		fungibles::{self, Inspect, Mutate, Transfer},
+		fungibles::{self, roles::Inspect as InspectRole, Inspect, Mutate, Transfer},
 		tokens::{DepositConsequence, WithdrawConsequence},
 		Currency, ReservableCurrency,
 	},
@@ -323,6 +323,16 @@ impl<T: Config> Pallet<T> {
 			.find(|(pallet, _)| pallet == &pallet_id.0)
 			.map(|(_, balance)| *balance)
 			.unwrap_or_default()
+	}
+
+	/// Called by the ERC20 precompile to verify whether an assetId exists or not
+	/// Checked against whether the asset contains an owner
+	pub fn asset_exists(asset_id: AssetId) -> bool {
+		if asset_id == T::NativeAssetId::get() {
+			true
+		} else {
+			<pallet_assets::Pallet<T>>::owner(asset_id).is_some()
+		}
 	}
 }
 


### PR DESCRIPTION
Currently the ERC20 precompile checks if an address is a precompile address by checking whether the asset exists. It does this by checking the total supply of an asset which is not always accurate as an asset can be created with 0 supply.

This has been changed to check the owner field of an asset, all assets will have an account stored in owner so this is far more accurate