### PR TITLE
Release/5.48.0

### DIFF
--- a/.github/ISSUE_TEMPLATE/release-template.md
+++ b/.github/ISSUE_TEMPLATE/release-template.md
@@ -15,6 +15,12 @@ assignees: ''
 
 **Client Version:** `<client-version>.0.0`
 
+## Key Changes:
+
+This release introduces the following changes:
+
+- (list of changes)
+
 ## PRs included:
 - (list of merged PRs (get from [here](https://github.com/futureversecom/trn-seed/pulls?q=is%3Aclosed))
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8544,7 +8544,7 @@ dependencies = [
 
 [[package]]
 name = "seed-client"
-version = "4.0.0"
+version = "5.0.0"
 dependencies = [
  "clap",
  "ethy-gadget",

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "seed-client"
-version = "4.0.0"
+version = "5.0.0"
 authors = ["The Root Network Team"]
 edition = "2021"
 publish = false

--- a/evm-precompiles/marketplace/README.md
+++ b/evm-precompiles/marketplace/README.md
@@ -20,7 +20,7 @@ interface Marketplace {
     
     function registerMarketplace(address marketplaceAccount, uint256 entitlement) external returns (uint marketplaceId);
     function sellNftWithMarketplaceId(address collectionAddress, uint256[] calldata serialNumberIds, address buyer, address paymentAsset, uint256 fixedPrice, uint256 duration, uint32 marketplaceId) external returns (uint listingId);
-    function SellNftWithoutMarketplace(address collectionAddress, uint256[] calldata serialNumberIds, address buyer, address paymentAsset, uint256 fixedPrice, uint256 duration) external returns (uint listingId);
+    function sellNftWithoutMarketplace(address collectionAddress, uint256[] calldata serialNumberIds, address buyer, address paymentAsset, uint256 fixedPrice, uint256 duration) external returns (uint listingId);
     function updateFixedPrice(uint128 listingId, uint256 newPrice) external;
     function buy(uint128 listingId) external payable;
     function auctionNftWithMarketplaceId(address collectionAddress, uint256[] calldata serialNumberIds, address paymentAsset, uint256 reservePrice, uint256 duration, uint256 marketplaceId) external payable;

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -152,7 +152,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("root"),
 	impl_name: create_runtime_str!("root"),
 	authoring_version: 1,
-	spec_version: 47,
+	spec_version: 48,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 6,


### PR DESCRIPTION
- Updated Client version to `5`
- Updated `spec_version` to `48`

[Changelog](https://github.com/futureversecom/trn-seed/issues/769)

### Misc updates

- Updated release PR template
- Fixed typo in marketplace precompile readme (solidity interface)