### PR TITLE
Rename the extrinsic `.submit_encoded_xrpl_transaction` to `.transact`

### DIFF
--- a/e2e/test/XRPL.test.ts
+++ b/e2e/test/XRPL.test.ts
@@ -100,14 +100,14 @@ describe("XRPL pallet", () => {
     const signature = sign(encodedSigningMessage, user.privateKey.slice(2));
 
     const cost = await api.tx.xrpl
-      .submitEncodedXrplTransaction(`0x${message}`, `0x${signature}`, extrinsic)
+      .transact(`0x${message}`, `0x${signature}`, extrinsic)
       .paymentInfo(user.address);
     expect(cost.partialFee.toNumber()).to.be.greaterThan(905_000).and.lessThan(920_000);
 
     // execute xaman tx extrinsic
     const events = await new Promise<any[]>(async (resolve) => {
       await api.tx.xrpl
-        .submitEncodedXrplTransaction(`0x${message}`, `0x${signature}`, extrinsic)
+        .transact(`0x${message}`, `0x${signature}`, extrinsic)
         .send(({ events = [], status }) => {
           if (status.isInBlock) resolve(events);
         });
@@ -196,14 +196,14 @@ describe("XRPL pallet", () => {
     const signature = sign(encodedSigningMessage, user.privateKey.slice(2));
 
     const cost = await api.tx.xrpl
-      .submitEncodedXrplTransaction(`0x${message}`, `0x${signature}`, extrinsic)
+      .transact(`0x${message}`, `0x${signature}`, extrinsic)
       .paymentInfo(user.address);
     expect(cost.partialFee.toNumber()).to.be.greaterThan(920_000).and.lessThan(935_000);
 
     // execute xaman tx extrinsic
     const events = await new Promise<any[]>(async (resolve) => {
       await api.tx.xrpl
-        .submitEncodedXrplTransaction(`0x${message}`, `0x${signature}`, extrinsic)
+        .transact(`0x${message}`, `0x${signature}`, extrinsic)
         .send(({ events = [], status }) => {
           if (status.isInBlock) resolve(events);
         });
@@ -292,14 +292,14 @@ describe("XRPL pallet", () => {
     const signature = sign(encodedSigningMessage, user.privateKey.slice(2));
 
     const cost = await api.tx.xrpl
-      .submitEncodedXrplTransaction(`0x${message}`, `0x${signature}`, extrinsic)
+      .transact(`0x${message}`, `0x${signature}`, extrinsic)
       .paymentInfo(user.address);
     expect(cost.partialFee.toNumber()).to.be.greaterThan(935_000).and.lessThan(950_000);
 
     // execute xaman tx extrinsic
     const events = await new Promise<any[]>(async (resolve) => {
       await api.tx.xrpl
-        .submitEncodedXrplTransaction(`0x${message}`, `0x${signature}`, extrinsic)
+        .transact(`0x${message}`, `0x${signature}`, extrinsic)
         .send(({ events = [], status }) => {
           if (status.isInBlock) resolve(events);
         });
@@ -417,14 +417,14 @@ describe("XRPL pallet", () => {
     const signature = sign(encodedSigningMessage, user.privateKey.slice(2));
 
     const cost = await api.tx.xrpl
-      .submitEncodedXrplTransaction(`0x${message}`, `0x${signature}`, extrinsic)
+      .transact(`0x${message}`, `0x${signature}`, extrinsic)
       .paymentInfo(user.address);
     expect(cost.partialFee.toNumber()).to.be.greaterThan(945_000).and.lessThan(965_000);
 
     // execute xaman tx extrinsic
     const events = await new Promise<any[]>(async (resolve) => {
       await api.tx.xrpl
-        .submitEncodedXrplTransaction(`0x${message}`, `0x${signature}`, extrinsic)
+        .transact(`0x${message}`, `0x${signature}`, extrinsic)
         .send(({ events = [], status }) => {
           if (status.isInBlock) resolve(events);
         });
@@ -559,14 +559,14 @@ describe("XRPL pallet", () => {
     const signature = sign(encodedSigningMessage, user.privateKey.slice(2));
 
     const cost = await api.tx.xrpl
-      .submitEncodedXrplTransaction(`0x${message}`, `0x${signature}`, extrinsic)
+      .transact(`0x${message}`, `0x${signature}`, extrinsic)
       .paymentInfo(user.address);
     expect(cost.partialFee.toNumber()).to.be.greaterThan(990_000).and.lessThan(1_005_000);
 
     // execute xaman tx extrinsic
     const events = await new Promise<any[]>(async (resolve) => {
       await api.tx.xrpl
-        .submitEncodedXrplTransaction(`0x${message}`, `0x${signature}`, extrinsic)
+        .transact(`0x${message}`, `0x${signature}`, extrinsic)
         .send(({ events = [], status }) => {
           if (status.isInBlock) resolve(events);
         });
@@ -711,14 +711,14 @@ describe("XRPL pallet", () => {
     const signature = sign(encodedSigningMessage, user.privateKey.slice(2));
 
     const cost = await api.tx.xrpl
-      .submitEncodedXrplTransaction(`0x${message}`, `0x${signature}`, extrinsic)
+      .transact(`0x${message}`, `0x${signature}`, extrinsic)
       .paymentInfo(futurepassAddress);
     expect(cost.partialFee.toNumber()).to.be.greaterThan(1_000_000).and.lessThan(1_015_000);
 
     // execute xaman tx extrinsic
     const events = await new Promise<any[]>(async (resolve) => {
       await api.tx.xrpl
-        .submitEncodedXrplTransaction(`0x${message}`, `0x${signature}`, extrinsic)
+        .transact(`0x${message}`, `0x${signature}`, extrinsic)
         .send(({ events = [], status }) => {
           if (status.isInBlock) resolve(events);
         });
@@ -864,7 +864,7 @@ describe("XRPL pallet", () => {
     await Promise.race([
       new Promise<any[]>(async (resolve) => {
         await api.tx.xrpl
-          .submitEncodedXrplTransaction(`0x${message}`, `0x${signature}`, extrinsic)
+          .transact(`0x${message}`, `0x${signature}`, extrinsic)
           .send(({ events = [], status }) => {
             if (status.isInBlock) resolve(events);
           });
@@ -877,12 +877,12 @@ describe("XRPL pallet", () => {
     expect(errorFound).to.be.true;
   });
 
-  it("fails if encoded call is nested submitEncodedXrplTransaction extrinsic", async () => {
+  it("fails if encoded call is nested transact extrinsic", async () => {
     const user = Wallet.createRandom();
     const publicKey = computePublicKey(user.publicKey, true);
 
     const innerCall = api.tx.system.remark("hello world");
-    const extrinsic = api.tx.xrpl.submitEncodedXrplTransaction(`0x00000000`, `0x00000000`, innerCall);
+    const extrinsic = api.tx.xrpl.transact(`0x00000000`, `0x00000000`, innerCall);
     const hashedExtrinsicWithoutPrefix = blake256(extrinsic.toHex().slice(6)).toString();
     const maxBlockNumber = +(await api.query.system.number()).toString() + 5;
 
@@ -910,7 +910,7 @@ describe("XRPL pallet", () => {
     await Promise.race([
       new Promise<any[]>(async (resolve) => {
         await api.tx.xrpl
-          .submitEncodedXrplTransaction(`0x${message}`, `0x${signature}`, extrinsic)
+          .transact(`0x${message}`, `0x${signature}`, extrinsic)
           .send(({ events = [], status }) => {
             if (status.isInBlock) resolve(events);
           });

--- a/pallet/xrpl/README.md
+++ b/pallet/xrpl/README.md
@@ -7,6 +7,6 @@ The signed transaction is a hex encoded message that contains an inner call (ext
 The transaction must contain specific [memo data](https://xrpl.org/transaction-common-fields.html#memos-field) of the `extrinsic` `memo type` - which encodes a `nonce`, `max_block_number` and a `scale_encoded_extrinsic` to be dispatched by the mapped ethereum address (derived from the provided pub key in the signed transaction).
 The scale_encoded_extrinsic is a SCALE encoded `Vec<u8>` of the extrinsic to be dispatched by the account.
 
-The pallet only contains a single extrinsic, `submit_encoded_xrpl_transaction` call; a self contained call that validates the signed transaction and dispatches the encoded extrinsic to the chain.
+The pallet only contains a single extrinsic, `transact` call; a self contained call that validates the signed transaction and dispatches the encoded extrinsic to the chain.
 
-A signature must be provided along with the encoded message (signed transaction) in the `submit_encoded_xrpl_transaction` call - which validates that the signed transaction was signed by the public key provided in the signed transaction.
+A signature must be provided along with the encoded message (signed transaction) in the `transact` call - which validates that the signed transaction was signed by the public key provided in the signed transaction.

--- a/pallet/xrpl/src/benchmarking.rs
+++ b/pallet/xrpl/src/benchmarking.rs
@@ -28,7 +28,7 @@ where
 benchmarks! {
 	where_clause { where <T as frame_system::Config>::AccountId: From<sp_core::H160> }
 
-  submit_encoded_xrpl_transaction {
+  transact {
 		// encoded call for: chainIid = 0, nonce = 0, max_block_number = 5, tip = 0, extrinsic = System::remark
 		let call: <T as Config>::RuntimeCall = frame_system::Call::<T>::remark { remark: Default::default() }.into();
 		let boxed_call = Box::new(call.clone());

--- a/pallet/xrpl/src/tests.rs
+++ b/pallet/xrpl/src/tests.rs
@@ -23,12 +23,12 @@ mod self_contained_call {
 	use super::*;
 
 	#[test]
-	fn submit_encoded_xrpl_transaction_validations() {
+	fn transact_validations() {
 		TestExt::<Test>::default().build().execute_with(|| {
       // encoded call for: chain_id = 0, nonce = 0, max_block_number = 5, tip = 0, extrinsic = System::remark
 			let call = mock::RuntimeCall::System(frame_system::Call::remark { remark: Default::default() });
       let tx_bytes = hex::decode("5916969036626990000000000000000000F236FD752B5E4C84810AB3D41A3C2580732102509540919FAACF9AB52146C9AA40DB68172D83777250B28E4679176E49CCDD9F81148E6106F6E98E7B21BFDFBFC3DEBA0EDED28A047AF9EA7C0965787472696E7369637D48303A303A353A303A35633933633236383339613137636235616366323765383961616330306639646433663531643161316161346234383266363930663634333633396665383732E1F1").unwrap();
-      assert_ok!(Xrpl::submit_encoded_xrpl_transaction(frame_system::RawOrigin::None.into(), BoundedVec::truncate_from(tx_bytes.clone()), BoundedVec::default(), Box::new(call)));
+      assert_ok!(Xrpl::transact(frame_system::RawOrigin::None.into(), BoundedVec::truncate_from(tx_bytes.clone()), BoundedVec::default(), Box::new(call)));
     });
 	}
 
@@ -41,7 +41,7 @@ mod self_contained_call {
 
 			// executing xrpl encoded transaction fails since caller is not root/sudo account
 			assert_noop!(
-				Xrpl::submit_encoded_xrpl_transaction(frame_system::RawOrigin::None.into(), BoundedVec::truncate_from(tx_bytes), BoundedVec::default(), Box::new(call)),
+				Xrpl::transact(frame_system::RawOrigin::None.into(), BoundedVec::truncate_from(tx_bytes), BoundedVec::default(), Box::new(call)),
 				BadOrigin,
 			);
 		});
@@ -56,7 +56,7 @@ mod self_contained_call {
 				let call = mock::RuntimeCall::System(frame_system::Call::remark { remark: Default::default() });
 
 				// encoded call for: chain_id = 1; nonce = 0, max_block_number = 5, tip = 0, extrinsic = System::remark; validates invalid chain id
-				let xt: mock::UncheckedExtrinsicT = fp_self_contained::UncheckedExtrinsic::new_unsigned(mock::RuntimeCall::Xrpl(crate::Call::submit_encoded_xrpl_transaction {
+				let xt: mock::UncheckedExtrinsicT = fp_self_contained::UncheckedExtrinsic::new_unsigned(mock::RuntimeCall::Xrpl(crate::Call::transact {
 					encoded_msg: BoundedVec::truncate_from(hex::decode("5916969036626990000000000000000000F236FD752B5E4C84810AB3D41A3C2580732102509540919FAACF9AB52146C9AA40DB68172D83777250B28E4679176E49CCDD9F81148E6106F6E98E7B21BFDFBFC3DEBA0EDED28A047AF9EA7C0965787472696E7369637D48303A303A353A303A66633730373832313235333862623238393633373338393034303237373630313464393765303033656136393430303533303538386134383434393662333337E1F1").unwrap()),
 					signature: BoundedVec::truncate_from(hex::decode("304402203D76BEF2D67A3B6FAB7972B7B382A654A5E78E74E16197E548F5494D69498256022017DB22937214C595ED2FFEDD9E99F9D830DF81E5B36A57AFFA021F05A497B9D1").unwrap()),
 					call: Box::new(call.clone()),
@@ -78,7 +78,7 @@ mod self_contained_call {
 
 				// encoded call for: chain_id = 0, nonce = 5, max_block_number = 5, tip = 0, extrinsic = System::remark; validates nonce too high
 				let tx_bytes = hex::decode("5916969036626990000000000000000000F236FD752B5E4C84810AB3D41A3C2580732102509540919FAACF9AB52146C9AA40DB68172D83777250B28E4679176E49CCDD9F81148E6106F6E98E7B21BFDFBFC3DEBA0EDED28A047AF9EA7C0965787472696E7369637D48303A353A353A303A35633933633236383339613137636235616366323765383961616330306639646433663531643161316161346234383266363930663634333633396665383732E1F1").unwrap();
-				let xt: mock::UncheckedExtrinsicT = fp_self_contained::UncheckedExtrinsic::new_unsigned(mock::RuntimeCall::Xrpl(crate::Call::submit_encoded_xrpl_transaction {
+				let xt: mock::UncheckedExtrinsicT = fp_self_contained::UncheckedExtrinsic::new_unsigned(mock::RuntimeCall::Xrpl(crate::Call::transact {
 					encoded_msg: BoundedVec::truncate_from(tx_bytes.clone()),
 					signature: BoundedVec::truncate_from(hex::decode("3044022038D2943A83270CFED21127AA72990F5B9D752AA7293743C872E0F65AAB5BEB8F02200634DD843C0276C36815648D133FE2B1854D55783207CFBC96F9C67E4775E0E3").unwrap()),
 					call: Box::new(call.clone()),
@@ -107,7 +107,7 @@ mod self_contained_call {
 				let call = mock::RuntimeCall::System(frame_system::Call::remark { remark: Default::default() });
 
 				// validate self contained extrinsic fails, call provided is not signed hashed extrinsic in memo data
-				let xt: mock::UncheckedExtrinsicT = fp_self_contained::UncheckedExtrinsic::new_unsigned(mock::RuntimeCall::Xrpl(crate::Call::submit_encoded_xrpl_transaction {
+				let xt: mock::UncheckedExtrinsicT = fp_self_contained::UncheckedExtrinsic::new_unsigned(mock::RuntimeCall::Xrpl(crate::Call::transact {
 					encoded_msg: BoundedVec::truncate_from(hex::decode("5916969036626990000000000000000000F236FD752B5E4C84810AB3D41A3C2580732102509540919FAACF9AB52146C9AA40DB68172D83777250B28E4679176E49CCDD9F81148E6106F6E98E7B21BFDFBFC3DEBA0EDED28A047AF9EA7C0965787472696E7369637D0A303A303A353A303A3030E1F1").unwrap()),
 					signature: BoundedVec::truncate_from(hex::decode("304502210081C0EFD0B5C85AC8C20765B95B44DCD0891619E83529A63A2350907B341EE168022006365C3AB530A1D529606D6EDDE18C76ECF42334FF0DC2140AD392C20305F898").unwrap()),
 					call: Box::new(call.clone()),
@@ -131,7 +131,7 @@ mod self_contained_call {
 				let tx_bytes = hex::decode("5916969036626990000000000000000000F236FD752B5E4C84810AB3D41A3C25807321021A765BED04797D2DD723C9FDC1ED9D20FEC478F7E8E7D16236F8504C5740C10781145FF8490F22ABFA576788227DB2E80D3F5F104654F9EA7C0965787472696E7369637D48303A303A353A303A35633933633236383339613137636235616366323765383961616330306639646433663531643161316161346234383266363930663634333633396665383732E1F1").unwrap();
 
 				// validate self contained extrinsic is invalid (no signature)
-				let xt: mock::UncheckedExtrinsicT = fp_self_contained::UncheckedExtrinsic::new_unsigned(mock::RuntimeCall::Xrpl(crate::Call::submit_encoded_xrpl_transaction {
+				let xt: mock::UncheckedExtrinsicT = fp_self_contained::UncheckedExtrinsic::new_unsigned(mock::RuntimeCall::Xrpl(crate::Call::transact {
 					encoded_msg: BoundedVec::truncate_from(tx_bytes.clone()),
 					signature: BoundedVec::default(),
 					call: Box::new(call.clone()),
@@ -142,7 +142,7 @@ mod self_contained_call {
 				);
 
 				// validate self contained extrinsic is invalid (invalid signature)
-				let xt: mock::UncheckedExtrinsicT = fp_self_contained::UncheckedExtrinsic::new_unsigned(mock::RuntimeCall::Xrpl(crate::Call::submit_encoded_xrpl_transaction {
+				let xt: mock::UncheckedExtrinsicT = fp_self_contained::UncheckedExtrinsic::new_unsigned(mock::RuntimeCall::Xrpl(crate::Call::transact {
 					encoded_msg: BoundedVec::truncate_from(tx_bytes.clone()),
 					signature: BoundedVec::truncate_from(hex::decode("304402205CD628B33CD2A89D735EBC139F21A3F2F138F7D687BBAF3E2CDFBBF8951919DC02204B65FC7FF3C2C1B1EEF10186CF6BDAA1C96E8F0814099EE5811C12F65E26A81E").unwrap()),
 					call: Box::new(call.clone()),
@@ -153,7 +153,7 @@ mod self_contained_call {
 				);
 
 				// validate self contained extrinsic fails, user does not have funds to pay for transaction
-				let xt: mock::UncheckedExtrinsicT = fp_self_contained::UncheckedExtrinsic::new_unsigned(mock::RuntimeCall::Xrpl(crate::Call::submit_encoded_xrpl_transaction {
+				let xt: mock::UncheckedExtrinsicT = fp_self_contained::UncheckedExtrinsic::new_unsigned(mock::RuntimeCall::Xrpl(crate::Call::transact {
 					encoded_msg: BoundedVec::truncate_from(tx_bytes.clone()),
 					signature: BoundedVec::truncate_from(hex::decode("3045022100A6E6546A845ED811FF833789ABE96A5D196737D6FAE0612F40639344DB3ABC2202205D4E3A3753EBC50CB5EBC1A0E861BE0DABA1EE062C08BB40DA9F65F20DEF0CF8").unwrap()),
 					call: Box::new(call.clone()),
@@ -190,7 +190,7 @@ mod self_contained_call {
 
 				let balance_before = Assets::balance(XRP_ASSET_ID, &caller);
 
-				let xt: mock::UncheckedExtrinsicT = fp_self_contained::UncheckedExtrinsic::new_unsigned(mock::RuntimeCall::Xrpl(crate::Call::submit_encoded_xrpl_transaction {
+				let xt: mock::UncheckedExtrinsicT = fp_self_contained::UncheckedExtrinsic::new_unsigned(mock::RuntimeCall::Xrpl(crate::Call::transact {
 					encoded_msg: BoundedVec::truncate_from(tx_bytes.clone()),
 					signature: BoundedVec::truncate_from(signature.clone()),
 					call: Box::new(call.clone()),

--- a/pallet/xrpl/src/weights.rs
+++ b/pallet/xrpl/src/weights.rs
@@ -48,7 +48,7 @@ use sp_std::marker::PhantomData;
 
 /// Weight functions needed for pallet_xrpl_transaction.
 pub trait WeightInfo {
-	fn submit_encoded_xrpl_transaction() -> Weight;
+	fn transact() -> Weight;
 }
 
 /// Weights for pallet_xrpl_transaction using the Substrate node and recommended hardware.
@@ -56,7 +56,7 @@ pub struct SubstrateWeight<T>(PhantomData<T>);
 impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	// Storage: MaintenanceMode BlockedCalls (r:1 w:0)
 	// Storage: MaintenanceMode BlockedPallets (r:1 w:0)
-	fn submit_encoded_xrpl_transaction() -> Weight {
+	fn transact() -> Weight {
 		Weight::from_ref_time(174_662_000 as u64)
 			.saturating_add(T::DbWeight::get().reads(2 as u64))
 	}
@@ -66,7 +66,7 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 impl WeightInfo for () {
 	// Storage: MaintenanceMode BlockedCalls (r:1 w:0)
 	// Storage: MaintenanceMode BlockedPallets (r:1 w:0)
-	fn submit_encoded_xrpl_transaction() -> Weight {
+	fn transact() -> Weight {
 		Weight::from_ref_time(174_662_000 as u64)
 			.saturating_add(RocksDbWeight::get().reads(2 as u64))
 	}

--- a/runtime/src/weights/pallet_xrpl.rs
+++ b/runtime/src/weights/pallet_xrpl.rs
@@ -33,7 +33,7 @@ pub struct WeightInfo<T>(PhantomData<T>);
 impl<T: frame_system::Config> pallet_xrpl::WeightInfo for WeightInfo<T> {
 	// Storage: MaintenanceMode BlockedCalls (r:1 w:0)
 	// Storage: MaintenanceMode BlockedPallets (r:1 w:0)
-	fn submit_encoded_xrpl_transaction() -> Weight {
+	fn transact() -> Weight {
 		Weight::from_ref_time(172_978_000 as u64)
 			.saturating_add(T::DbWeight::get().reads(2 as u64))
 	}


### PR DESCRIPTION
This is to make it inline with `ethereum.transact` and `doughnut.transact` which are all self-contained calls

**PR checklist**  

- [ ] Describe the added/changed/fixed/removed behaviour
- [ ] Tag related issue(s)
- [ ] Add appropriate unit tests and/or integration tests to the [integration test repository](https://github.com/futureversecom/seed-integration-tests)
