### PR TITLE
Release/5.49.0

### DIFF
--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -153,7 +153,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("root"),
 	impl_name: create_runtime_str!("root"),
 	authoring_version: 1,
-	spec_version: 48,
+	spec_version: 49,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 6,


### PR DESCRIPTION
- Updated `spec_version` to `49`

[Changelog](https://github.com/futureversecom/trn-seed/issues/787)