### PR TITLE
Pallet crowdsale upd

### DIFF
--- a/pallet/crowdsale/src/impls.rs
+++ b/pallet/crowdsale/src/impls.rs
@@ -14,7 +14,10 @@ use scale_info::prelude::format;
 
 impl<T: Config> Pallet<T> {
 	/// Creates a unique voucher asset for a sale. Returns the AssetId of the created asset
-	pub(crate) fn create_voucher_asset(sale_id: SaleId, decimals: u8) -> Result<AssetId, DispatchError> {
+	pub(crate) fn create_voucher_asset(
+		sale_id: SaleId,
+		decimals: u8,
+	) -> Result<AssetId, DispatchError> {
 		let voucher_owner = T::PalletId::get().into_account_truncating();
 		let voucher_asset_id = T::MultiCurrency::create_with_metadata(
 			&voucher_owner,
@@ -93,8 +96,12 @@ impl<T: Config> Pallet<T> {
 
 				let refunded_vouchers = sale_info.funds_raised.saturating_sub(crowd_sale_target);
 				if refunded_vouchers > 0 {
-					T::MultiCurrency::mint_into(sale_info.payment_asset, &sale_info.admin, refunded_vouchers)
-						.map_err(|_| Error::<T>::AssetMintFailed)?;
+					T::MultiCurrency::mint_into(
+						sale_info.payment_asset,
+						&sale_info.admin,
+						refunded_vouchers,
+					)
+					.map_err(|_| Error::<T>::AssetMintFailed)?;
 				}
 
 				// TODO: get contributers list from storage map based on sale ID
@@ -103,7 +110,8 @@ impl<T: Config> Pallet<T> {
 				let contribution = 500_000_000; // 500 root
 				let vouchers_quantity_redeemed = contribution / voucher_price; // 500_000_000 / 20_000_000 = 25
 				let voucher_decimals = T::MultiCurrency::decimals(&sale_info.payment_asset);
-        let voucher_amount = vouchers_quantity_redeemed.saturating_mul(10u32.pow(voucher_decimals as u32).into());
+				let voucher_amount = vouchers_quantity_redeemed
+					.saturating_mul(10u32.pow(voucher_decimals as u32).into());
 				T::MultiCurrency::mint_into(sale_info.voucher, &contributor, voucher_amount)
 					.map_err(|_| Error::<T>::AssetMintFailed)?;
 

--- a/pallet/crowdsale/src/impls.rs
+++ b/pallet/crowdsale/src/impls.rs
@@ -14,13 +14,13 @@ use scale_info::prelude::format;
 
 impl<T: Config> Pallet<T> {
 	/// Creates a unique voucher asset for a sale. Returns the AssetId of the created asset
-	pub(crate) fn create_voucher_asset(sale_id: SaleId) -> Result<AssetId, DispatchError> {
+	pub(crate) fn create_voucher_asset(sale_id: SaleId, decimals: u8) -> Result<AssetId, DispatchError> {
 		let voucher_owner = T::PalletId::get().into_account_truncating();
 		let voucher_asset_id = T::MultiCurrency::create_with_metadata(
 			&voucher_owner,
 			format!("CrowdSale Voucher-{}", sale_id).as_bytes().to_vec(),
 			format!("CSV-{}", sale_id).as_bytes().to_vec(),
-			VOUCHER_DECIMALS,
+			decimals,
 			None,
 		)
 		.map_err(|_| Error::<T>::CreateAssetFailed)?;
@@ -52,7 +52,8 @@ impl<T: Config> Pallet<T> {
 		};
 
 		// Return total vouchers converted to the correct decimals
-		account_contribution * 10u128.pow(VOUCHER_DECIMALS as u32) / voucher_price
+		todo!("Calculate voucher rewards based on the account contribution and voucher price.")
+		// account_contribution * 10u128.pow(VOUCHER_DECIMALS as u32) / voucher_price
 	}
 
 	/// Close all crowdsales that are scheduled to end this block

--- a/pallet/crowdsale/src/lib.rs
+++ b/pallet/crowdsale/src/lib.rs
@@ -168,8 +168,8 @@ pub mod pallet {
 		CreateAssetFailed,
 		/// Asset transfer failed
 		AssetTransferFailed,
-    /// Asset mint failed
-    AssetMintFailed,
+		/// Asset mint failed
+		AssetMintFailed,
 		/// NFT mint failed
 		NFTMintFailed,
 		/// The NFT collection max issuance is not set
@@ -200,7 +200,8 @@ pub mod pallet {
 	#[pallet::call]
 	impl<T: Config> Pallet<T> {
 		/// Initialize a new crowdsale with the given parameters.
-    /// The provided collection max_issuance must be set and the collection must not have minted any NFTs.
+		/// The provided collection max_issuance must be set and the collection must not have minted
+		/// any NFTs.
 		///
 		/// Parameters:
 		/// - `payment_asset`: Asset id of the token that will be used to redeem the NFTs at the end
@@ -239,8 +240,8 @@ pub mod pallet {
 				return Err(Error::<T>::InvalidAsset.into())
 			}
 
-      // ensure soft_cap_price is not zero - prevent future div by zero
-      ensure!(!soft_cap_price.is_zero(), Error::<T>::InvalidAsset);
+			// ensure soft_cap_price is not zero - prevent future div by zero
+			ensure!(!soft_cap_price.is_zero(), Error::<T>::InvalidAsset);
 
 			// TODO, maybe set the max issuance here?
 			// Might be bad user experience to create a collection and fail due to one of these 2
@@ -259,7 +260,7 @@ pub mod pallet {
 			);
 
 			// create voucher asset
-      let voucher_decimals = T::MultiCurrency::decimals(&payment_asset);
+			let voucher_decimals = T::MultiCurrency::decimals(&payment_asset);
 			let voucher_asset_id = Self::create_voucher_asset(sale_id, voucher_decimals)?;
 
 			// store the sale information
@@ -414,14 +415,10 @@ pub mod pallet {
 				// burn vouchers from the user, will fail if the user does not have enough vouchers
 				// since 1:1 mapping between vouchers and NFTs, we can use the quantity * decimals
 				// as the amount burned
-        let voucher_decimals = T::MultiCurrency::decimals(&sale_info.payment_asset);
-        let voucher_amount = quantity.saturating_mul(10u32.pow(voucher_decimals as u32));
-				T::MultiCurrency::burn_from(
-					sale_info.voucher,
-					&who,
-					voucher_amount.into(),
-				)
-				.map_err(|_| Error::<T>::AssetTransferFailed)?;
+				let voucher_decimals = T::MultiCurrency::decimals(&sale_info.payment_asset);
+				let voucher_amount = quantity.saturating_mul(10u32.pow(voucher_decimals as u32));
+				T::MultiCurrency::burn_from(sale_info.voucher, &who, voucher_amount.into())
+					.map_err(|_| Error::<T>::AssetTransferFailed)?;
 
 				// mint the NFT(s) to the user
 				T::NFTExt::do_mint(

--- a/pallet/crowdsale/src/lib.rs
+++ b/pallet/crowdsale/src/lib.rs
@@ -239,6 +239,9 @@ pub mod pallet {
 				return Err(Error::<T>::InvalidAsset.into())
 			}
 
+      // ensure soft_cap_price is not zero - prevent future div by zero
+      ensure!(!soft_cap_price.is_zero(), Error::<T>::InvalidAsset);
+
 			// TODO, maybe set the max issuance here?
 			// Might be bad user experience to create a collection and fail due to one of these 2
 			// Potentially a better approach would be to create the collection here.

--- a/pallet/crowdsale/src/lib.rs
+++ b/pallet/crowdsale/src/lib.rs
@@ -415,10 +415,11 @@ pub mod pallet {
 				// since 1:1 mapping between vouchers and NFTs, we can use the quantity * decimals
 				// as the amount burned
         let voucher_decimals = T::MultiCurrency::decimals(&sale_info.payment_asset);
+        let voucher_amount = quantity.saturating_mul(10u32.pow(voucher_decimals as u32));
 				T::MultiCurrency::burn_from(
 					sale_info.voucher,
 					&who,
-					quantity.saturating_mul(voucher_decimals.into()).into(),
+					voucher_amount.into(),
 				)
 				.map_err(|_| Error::<T>::AssetTransferFailed)?;
 

--- a/pallet/crowdsale/src/tests.rs
+++ b/pallet/crowdsale/src/tests.rs
@@ -135,10 +135,10 @@ mod calculate_voucher_rewards {
 	#[test]
 	fn calculate_voucher_rewards_partial_rewards() {
 		TestExt::<Test>::default().build().execute_with(|| {
-			let soft_cap_price = 50;
-			let funds_raised = 10_000_000;
-			let voucher_total_supply = 135_000; // 135000 * 50 = 6_750_000
-			let contribution = 50;
+			let soft_cap_price = 50_000_000;
+			let funds_raised = 10_000_000_000_000;
+			let voucher_total_supply = 135_000; // 135000 * 50 = 6_750_000_000_000
+			let contribution = 50_000_000;
 
 			let user_vouchers = Pallet::<Test>::calculate_voucher_rewards(
 				soft_cap_price,
@@ -148,9 +148,85 @@ mod calculate_voucher_rewards {
 			);
 
 			// We should get 0.675676 vouchers (at 6DP)
+			//               0.675675675675675675
+			//               0.675000000000000000
 			// TODO Figure out rounding... Should probably be 675676
 			let expected_vouchers = 675675;
 			assert_eq!(user_vouchers, expected_vouchers);
+		});
+	}
+
+	#[test]
+	fn calculate_voucher_rewards_partial_rewards_2() {
+		TestExt::<Test>::default().build().execute_with(|| {
+			let soft_cap_price = 10_000_000;
+			let funds_raised = 20_000_000_000;
+			let voucher_total_supply = 1000;
+			let contribution = 500_000_000;
+
+			let user_vouchers = Pallet::<Test>::calculate_voucher_rewards(
+				soft_cap_price,
+				funds_raised,
+				contribution,
+				voucher_total_supply,
+			);
+
+			let expected_vouchers = 25_000_000;
+			assert_eq!(user_vouchers, expected_vouchers);
+		});
+	}
+
+	#[test]
+	fn calculate_voucher_rewards_3() {
+		TestExt::<Test>::default().build().execute_with(|| {
+			let soft_cap_price = 10_000_000_000_000_000_000;
+			let funds_raised = 20_000_000_000_000_000_000_000;
+			let voucher_total_supply = 1000;
+			let contribution = 500_000_000_000_000_000_000;
+
+			let user_vouchers = Pallet::<Test>::calculate_voucher_rewards(
+				soft_cap_price,
+				funds_raised,
+				contribution,
+				voucher_total_supply,
+			);
+
+			let expected_vouchers = 25_000_000;
+			assert_eq!(user_vouchers, expected_vouchers);
+		});
+	}
+
+	// TODO
+
+	#[test]
+	fn calculate_voucher_rewards_rounding() {
+		TestExt::<Test>::default().build().execute_with(|| {
+			let soft_cap_price = 10_000_000_000;
+			let voucher_total_supply = 1000;
+
+			let mut funds_raised = 0;
+			let mut contributions: Vec<Balance> = Vec::new();
+			for i in 0..1000000 {
+				funds_raised += i;
+				contributions.push(i);
+			}
+
+			let mut total_vouchers = 0;
+			for i in 0..1000000 {
+				let user_vouchers = Pallet::<Test>::calculate_voucher_rewards(
+					soft_cap_price,
+					funds_raised * 1_000_000,
+					i * 1_000_000,
+					voucher_total_supply,
+				);
+				total_vouchers += user_vouchers;
+			}
+
+			let test: Balance = 10;
+			let remainder = test % 3;
+			let x = test / 3;
+			println!("x: {}, rem: {}", x, remainder);
+			assert_eq!(total_vouchers, voucher_total_supply * 1_000_000);
 		});
 	}
 }

--- a/pallet/crowdsale/src/types.rs
+++ b/pallet/crowdsale/src/types.rs
@@ -7,9 +7,6 @@ use sp_core::U256;
 /// The unique identifier for a sale
 pub type SaleId = u64;
 
-/// How many decimals the voucher assets will have
-pub const VOUCHER_DECIMALS: u8 = 6;
-
 #[derive(Clone, Copy, Encode, Decode, RuntimeDebug, PartialEq, Eq, TypeInfo, MaxEncodedLen)]
 pub struct SaleInformation<AccountId, BlockNumber> {
 	/// The current sale status
@@ -25,7 +22,7 @@ pub struct SaleInformation<AccountId, BlockNumber> {
 	/// Total funds raised during the crowdsale
 	pub funds_raised: Balance,
 	/// The voucher asset id to be paid out
-	pub voucher: AssetId,
+	pub voucher: AssetId, // TODO: could potentially be (AssedId, decimals)
 	/// How long the sale will last in blocks
 	pub sale_duration: BlockNumber,
 }
@@ -36,10 +33,6 @@ pub enum SaleStatus {
 	Disabled,
 	/// The sale has been started and is accepting payments
 	Enabled,
-	/// The sale is complete and vouchers are being paid out
-	Paying,
-	/// The sale is complete and refunds are being processed
-	Refunding,
 	/// The sale is complete and is no longer active
 	Closed,
 }

--- a/pallet/crowdsale/src/types.rs
+++ b/pallet/crowdsale/src/types.rs
@@ -7,6 +7,9 @@ use sp_core::U256;
 /// The unique identifier for a sale
 pub type SaleId = u64;
 
+/// Number of decimal places for each voucher asset
+pub const VOUCHER_DECIMALS: u8 = 6;
+
 #[derive(Clone, Copy, Encode, Decode, RuntimeDebug, PartialEq, Eq, TypeInfo, MaxEncodedLen)]
 pub struct SaleInformation<AccountId, BlockNumber> {
 	/// The current sale status


### PR DESCRIPTION
# Improvements
- added log_target
- decimals for voucher is based on the payment_asset for easier 1:1 conversions
- have a concrete example in `close_sales_at` function for calculations, refunds and contributor voucher redemption

## TODO
- verify the code and commits
- if agreement, merge to base PR branch
- next steps would be thinking about how we can manage the `SaleParticipants` or `Contributions` (rename the storage item)
  - we may need double storage map instead
  - we may need to limit no. of participants that can redeem vouchers per block