### PR TITLE
Emit event for SFT transfers from marketplace

### DIFF
--- a/pallet/common/src/lib.rs
+++ b/pallet/common/src/lib.rs
@@ -494,12 +494,11 @@ pub trait NFTExt {
 
 pub trait SFTExt {
 	type AccountId: Debug + PartialEq + Clone;
-	type MaxSerialsPerMint: Get<u32>;
 
 	fn do_transfer(
 		origin: Self::AccountId,
 		collection_id: CollectionUuid,
-		serial_numbers: BoundedVec<(SerialNumber, Balance), Self::MaxSerialsPerMint>,
+		serial_numbers: Vec<(SerialNumber, Balance)>,
 		new_owner: Self::AccountId,
 	) -> DispatchResult;
 
@@ -510,13 +509,6 @@ pub trait SFTExt {
 		token_id: TokenId,
 		amount: Balance,
 		who: &Self::AccountId,
-	) -> DispatchResult;
-
-	fn transfer_reserved_balance(
-		token_id: TokenId,
-		amount: Balance,
-		from: &Self::AccountId,
-		to: &Self::AccountId,
 	) -> DispatchResult;
 
 	fn get_royalties_schedule(

--- a/pallet/common/src/test_utils.rs
+++ b/pallet/common/src/test_utils.rs
@@ -305,7 +305,7 @@ macro_rules! impl_pallet_sft_config {
 		parameter_types! {
 			pub const SftPalletId: PalletId = PalletId(*b"sftokens");
 			pub const MaxTokensPerSftCollection: u32 = 10_000;
-			pub const MaxSerialsPerSftMint: u32 = 10;
+			pub const MaxSerialsPerSftMint: u32 = 100;
 			pub const MaxOwnersPerSftToken: u32 = 100;
 		}
 

--- a/pallet/marketplace/src/tests.rs
+++ b/pallet/marketplace/src/tests.rs
@@ -2868,6 +2868,29 @@ mod buy_sft {
 					AssetsExt::reducible_balance(NativeAssetId::get(), &fee_pot_account, false),
 					5, // 0.5% of 1000
 				);
+
+				System::assert_has_event(MockEvent::Marketplace(
+					Event::<Test>::FixedPriceSaleComplete {
+						tokens: sft_token.clone(),
+						listing_id,
+						marketplace_id: None,
+						price,
+						payment_asset: NativeAssetId::get(),
+						seller: token_owner,
+						buyer,
+					},
+				));
+
+				System::assert_has_event(
+					pallet_sft::Event::<Test>::Transfer {
+						previous_owner: token_owner,
+						collection_id,
+						serial_numbers: BoundedVec::truncate_from(vec![token_id.1]),
+						balances: BoundedVec::truncate_from(vec![sell_quantity]),
+						new_owner: buyer
+					}.into()
+				);
+
 			});
 	}
 

--- a/pallet/marketplace/src/tests.rs
+++ b/pallet/marketplace/src/tests.rs
@@ -2887,10 +2887,10 @@ mod buy_sft {
 						collection_id,
 						serial_numbers: BoundedVec::truncate_from(vec![token_id.1]),
 						balances: BoundedVec::truncate_from(vec![sell_quantity]),
-						new_owner: buyer
-					}.into()
+						new_owner: buyer,
+					}
+					.into(),
 				);
-
 			});
 	}
 

--- a/pallet/marketplace/src/types.rs
+++ b/pallet/marketplace/src/types.rs
@@ -145,11 +145,18 @@ impl<T: Config> ListingTokens<T> {
 					to.clone(),
 				)?;
 			},
-			ListingTokens::Sft(sfts) =>
+			ListingTokens::Sft(sfts) => {
 				for (serial_number, balance) in sfts.serial_numbers.iter() {
 					let token_id = (sfts.collection_id, *serial_number);
-					T::SFTExt::transfer_reserved_balance(token_id, *balance, from, to)?;
-				},
+					T::SFTExt::free_reserved_balance(token_id, *balance, from)?;
+				}
+				T::SFTExt::do_transfer(
+					*from,
+					sfts.collection_id,
+					sfts.clone().serial_numbers.into_inner(),
+					*to,
+				)?;
+			},
 		}
 		Ok(())
 	}

--- a/pallet/sft/src/lib.rs
+++ b/pallet/sft/src/lib.rs
@@ -228,6 +228,8 @@ pub mod pallet {
 		Overflow,
 		/// This collection has not allowed public minting
 		PublicMintDisabled,
+		/// The number of tokens have exceeded the max tokens allowed
+		TokenLimitExceeded,
 	}
 
 	#[pallet::call]

--- a/pallet/sft/src/lib.rs
+++ b/pallet/sft/src/lib.rs
@@ -315,7 +315,7 @@ pub mod pallet {
 
 		/// Transfer ownership of an SFT
 		/// Caller must be the token owner
-		#[pallet::weight(T::WeightInfo::transfer())]
+		#[pallet::weight(T::WeightInfo::transfer(serial_numbers.len() as u32))]
 		#[transactional]
 		pub fn transfer(
 			origin: OriginFor<T>,

--- a/pallet/sft/src/types.rs
+++ b/pallet/sft/src/types.rs
@@ -171,18 +171,6 @@ where
 
 		balance.remove_reserve(amount)
 	}
-
-	/// Transfers some balance from one accounts reserved balance to another accounts free balance
-	/// This is useful for transferring a balance that is reserved for a sale
-	pub fn transfer_reserved_balance(
-		&mut self,
-		from: &AccountId,
-		to: &AccountId,
-		amount: Balance,
-	) -> Result<(), TokenBalanceError> {
-		self.free_reserved_balance(from, amount)?;
-		self.transfer_balance(from, to, amount)
-	}
 }
 
 /// Holds information about a users balance of a specific token

--- a/pallet/sft/src/weights.rs
+++ b/pallet/sft/src/weights.rs
@@ -53,7 +53,7 @@ pub trait WeightInfo {
 	fn set_mint_fee() -> Weight;
 	fn create_token() -> Weight;
 	fn mint() -> Weight;
-	fn transfer() -> Weight;
+	fn transfer(p: u32) -> Weight;
 	fn burn() -> Weight;
 	fn set_owner() -> Weight;
 	fn set_max_issuance() -> Weight;
@@ -90,10 +90,15 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: Sft TokenInfo (r:1 w:1)
-	fn transfer() -> Weight {
-		Weight::from_ref_time(62_718_000 as u64)
+	/// The range of component `p` is `[1, 50]`.
+	fn transfer(p: u32, ) -> Weight {
+		Weight::from_ref_time(18_000_000 as u64)
+			// Standard Error: 3_822
+			.saturating_add(Weight::from_ref_time(3_381_220 as u64).saturating_mul(p as u64))
 			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().reads((1 as u64).saturating_mul(p as u64)))
 			.saturating_add(T::DbWeight::get().writes(1 as u64))
+			.saturating_add(T::DbWeight::get().writes((1 as u64).saturating_mul(p as u64)))
 	}
 	// Storage: Sft TokenInfo (r:1 w:1)
 	fn burn() -> Weight {
@@ -175,10 +180,15 @@ impl WeightInfo for () {
 			.saturating_add(RocksDbWeight::get().writes(1 as u64))
 	}
 	// Storage: Sft TokenInfo (r:1 w:1)
-	fn transfer() -> Weight {
-		Weight::from_ref_time(62_718_000 as u64)
+	/// The range of component `p` is `[1, 50]`.
+	fn transfer(p: u32, ) -> Weight {
+		Weight::from_ref_time(18_000_000 as u64)
+			// Standard Error: 3_822
+			.saturating_add(Weight::from_ref_time(3_381_220 as u64).saturating_mul(p as u64))
 			.saturating_add(RocksDbWeight::get().reads(1 as u64))
+			.saturating_add(RocksDbWeight::get().reads((1 as u64).saturating_mul(p as u64)))
 			.saturating_add(RocksDbWeight::get().writes(1 as u64))
+			.saturating_add(RocksDbWeight::get().writes((1 as u64).saturating_mul(p as u64)))
 	}
 	// Storage: Sft TokenInfo (r:1 w:1)
 	fn burn() -> Weight {

--- a/pallet/sft/src/weights.rs
+++ b/pallet/sft/src/weights.rs
@@ -92,7 +92,7 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	// Storage: Sft TokenInfo (r:1 w:1)
 	/// The range of component `p` is `[1, 50]`.
 	fn transfer(p: u32, ) -> Weight {
-		Weight::from_ref_time(18_000_000 as u64)
+		Weight::from_ref_time(62_718_000 as u64)
 			// Standard Error: 3_822
 			.saturating_add(Weight::from_ref_time(3_381_220 as u64).saturating_mul(p as u64))
 			.saturating_add(T::DbWeight::get().reads(1 as u64))
@@ -182,7 +182,7 @@ impl WeightInfo for () {
 	// Storage: Sft TokenInfo (r:1 w:1)
 	/// The range of component `p` is `[1, 50]`.
 	fn transfer(p: u32, ) -> Weight {
-		Weight::from_ref_time(18_000_000 as u64)
+		Weight::from_ref_time(62_718_000 as u64)
 			// Standard Error: 3_822
 			.saturating_add(Weight::from_ref_time(3_381_220 as u64).saturating_mul(p as u64))
 			.saturating_add(RocksDbWeight::get().reads(1 as u64))

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -434,7 +434,7 @@ parameter_types! {
 	pub const MarketplacePalletId: PalletId = PalletId(*b"marketpl");
 	/// How long listings are open for by default
 	pub const DefaultListingDuration: BlockNumber = DAYS * 3;
-	pub const MaxTokensPerListing: u32 = 100;
+	pub const MaxTokensPerListing: u32 = 1000;
 	pub const MaxListingsPerMultiBuy: u32 = 50;
 	pub const MaxOffers: u32 = 100;
 	pub const MarketplaceNetworkFeePercentage: Permill = Permill::from_perthousand(5);
@@ -460,7 +460,7 @@ parameter_types! {
 	pub const SftPalletId: PalletId = PalletId(*b"sftokens");
 	pub const MaxTokensPerSftCollection: u32 = 1_000_000;
 	pub const MaxOwnersPerSftCollection: u32 = 1_000_000;
-	pub const MaxSerialsPerMint: u32 = 100; // Higher values can be storage heavy
+	pub const MaxSerialsPerMint: u32 = 1000; // Higher values can be storage heavy
 }
 impl pallet_sft::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -434,7 +434,7 @@ parameter_types! {
 	pub const MarketplacePalletId: PalletId = PalletId(*b"marketpl");
 	/// How long listings are open for by default
 	pub const DefaultListingDuration: BlockNumber = DAYS * 3;
-	pub const MaxTokensPerListing: u32 = 1000;
+	pub const MaxTokensPerListing: u32 = 100;
 	pub const MaxListingsPerMultiBuy: u32 = 50;
 	pub const MaxOffers: u32 = 100;
 	pub const MarketplaceNetworkFeePercentage: Permill = Permill::from_perthousand(5);

--- a/runtime/src/weights/pallet_sft.rs
+++ b/runtime/src/weights/pallet_sft.rs
@@ -58,7 +58,7 @@ impl<T: frame_system::Config> pallet_sft::WeightInfo for WeightInfo<T> {
 	// Storage: Sft TokenInfo (r:1 w:1)
 	/// The range of component `p` is `[1, 50]`.
 	fn transfer(p: u32, ) -> Weight {
-		Weight::from_ref_time(18_000_000 as u64)
+		Weight::from_ref_time(62_718_000 as u64)
 			// Standard Error: 3_822
 			.saturating_add(Weight::from_ref_time(3_381_220 as u64).saturating_mul(p as u64))
 			.saturating_add(T::DbWeight::get().reads(1 as u64))

--- a/runtime/src/weights/pallet_sft.rs
+++ b/runtime/src/weights/pallet_sft.rs
@@ -56,10 +56,15 @@ impl<T: frame_system::Config> pallet_sft::WeightInfo for WeightInfo<T> {
 			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: Sft TokenInfo (r:1 w:1)
-	fn transfer() -> Weight {
-		Weight::from_ref_time(64_386_000 as u64)
+	/// The range of component `p` is `[1, 50]`.
+	fn transfer(p: u32, ) -> Weight {
+		Weight::from_ref_time(18_000_000 as u64)
+			// Standard Error: 3_822
+			.saturating_add(Weight::from_ref_time(3_381_220 as u64).saturating_mul(p as u64))
 			.saturating_add(T::DbWeight::get().reads(1 as u64))
+			.saturating_add(T::DbWeight::get().reads((1 as u64).saturating_mul(p as u64)))
 			.saturating_add(T::DbWeight::get().writes(1 as u64))
+			.saturating_add(T::DbWeight::get().writes((1 as u64).saturating_mul(p as u64)))
 	}
 	// Storage: Sft TokenInfo (r:1 w:1)
 	fn burn() -> Weight {


### PR DESCRIPTION
Removes free_reserve_and_transfer method on SFTExt and uses free_reserve and do_transfer methods individually to emit a transfer event in do_transfer