### PR TITLE
Pallet crowdsale simplify calculation

### DIFF
--- a/pallet/crowdsale/src/impls.rs
+++ b/pallet/crowdsale/src/impls.rs
@@ -11,7 +11,10 @@
 
 use crate::*;
 use alloc::format;
-use frame_support::sp_runtime::traits::{BlakeTwo256, Hash};
+use frame_support::{
+	sp_runtime::traits::{BlakeTwo256, Hash},
+	traits::fungibles::Inspect,
+};
 use sp_core::U256;
 
 impl<T: Config> Pallet<T> {
@@ -52,20 +55,21 @@ impl<T: Config> Pallet<T> {
 	/// 'total_funds_raised' - How many funds were raised in total for the sale
 	/// 'account_contribution' - How much has the user contributed to this round?
 	/// 'voucher_total_supply' - Also NFT max_issuance
-	pub(crate) fn calculate_voucher_rewards_old(
+	pub(crate) fn calculate_voucher_rewards(
 		soft_cap_price: Balance,
 		total_funds_raised: Balance,
-		account_contribution: Balance,
+		account_contribution: U256,
 		voucher_total_supply: Balance,
-	) -> Balance {
+	) -> Result<Balance, &'static str> {
 		// Calculate the price of the soft cap across the total supply. This is our baseline
-		let crowd_sale_target = soft_cap_price * voucher_total_supply;
+		let crowd_sale_target = soft_cap_price.saturating_mul(voucher_total_supply);
 
 		// Check if we are over or under committed
 		let voucher_price: Balance = if total_funds_raised > crowd_sale_target {
 			// We are over committed. Calculate the voucher price based on the total
-			total_funds_raised / voucher_total_supply
-		// Self::divide_rounding(total_funds_raised, voucher_total_supply)
+			total_funds_raised
+				.checked_div(voucher_total_supply)
+				.ok_or("Voucher max supply must be greater than 0")?
 		} else {
 			// We are under committed so we will pay out the soft cap
 			soft_cap_price
@@ -73,124 +77,44 @@ impl<T: Config> Pallet<T> {
 
 		// Add 6 zeros to the account contribution to match the voucher price decimals.
 		// If we add this later, we will lose precision
-		let contribution = account_contribution * 10u128.pow(VOUCHER_DECIMALS as u32);
-		// divide account_contribution by voucher_price and round up or down
-		let voucher_quantity = Self::divide_rounding(contribution, voucher_price);
+		let contribution =
+			account_contribution.saturating_mul(U256::from(10_u128.pow(VOUCHER_DECIMALS as u32)));
 
-		voucher_quantity
-	}
-
-	// Divide two numbers and round up if the remainder is greater than half the divisor
-	fn divide_rounding(numerator: Balance, denominator: Balance) -> Balance {
-		let quotient = numerator / denominator;
-		let remainder = numerator % denominator;
-
-		if remainder * 2 >= denominator {
-			quotient //+ 1
-		} else {
-			quotient
-		}
-	}
-
-	/// Calculate how many vouchers an account should receive based on their contribution at the
-	/// end of the sale
-	/// 'soft_cap_price' - What was the initial soft cap price?
-	/// 'total_funds_raised' - How many funds were raised in total for the sale
-	/// 'account_contribution' - How much has the user contributed to this round?
-	/// 'voucher_max_supply' - The max amount of vouchers to be minted.
-	///                        Also NFT max_issuance
-	/// 'voucher_current_supply' - The current amount of vouchers minted to participants. Excluding
-	/// 						   any vouchers refunded to the admin
-	/// 'total_paid_contributions' - The total amount of contributions paid so far
-	///
-	/// Note. The standard calculation involves dividing the users contribution by
-	/// the voucher_price. This works, however we end up accumulating inaccuracies due to the
-	/// precision of using 6 decimal places.
-	/// We can counter this by calculating the total supply of vouchers after this payment is made
-	/// and subtracting the amount of vouchers that were minted before this payment was made.
-	/// That way we spread the inaccuracies across multiple accounts and end up with a more accurate
-	/// total supply.
-	/// As a last precaution, we limit the total supply to the max supply to avoid minting more than
-	/// the max supply.
-	pub(crate) fn calculate_voucher_rewards(
-		soft_cap_price: Balance,
-		total_funds_raised: Balance,
-		account_contribution: U256,
-		voucher_max_supply: Balance,
-		voucher_current_supply: Balance,
-		total_paid_contributions: U256,
-	) -> Result<Balance, &'static str> {
-		// Calculate the price of the soft cap across the total supply. This is our baseline
-		let crowd_sale_target = soft_cap_price.saturating_mul(voucher_max_supply);
-
-		// Check if we are over or under committed
-		let voucher_price: Balance = if total_funds_raised > crowd_sale_target {
-			// We are over committed. Calculate the voucher price based on the total
-			total_funds_raised
-				.checked_div(voucher_max_supply)
-				.ok_or("Voucher max supply must be greater than 0")?
-		} else {
-			// We are under committed so we will pay out the soft cap
-			soft_cap_price
-		};
-
-		// Total contributions of all payments prior to this payment + the contributions
-		// from this account
-		// Converted to U256 to avoid overflow during calculations
-		let contribution_after: U256 =
-			account_contribution.saturating_add(total_paid_contributions);
-
-		// Add voucher decimals due to the fact that voucher_total_supply is excluding decimals
-		// (As we need a whole number of NFTs)
-		// Note. We add decimals here to avoid losing precision
-		let contribution_after =
-			contribution_after.saturating_mul(U256::from(10_u128.pow(VOUCHER_DECIMALS as u32)));
-
-		// The total supply of vouchers after this payment is made
-		let voucher_supply_after = contribution_after
+		// divide account_contribution by voucher_price and down
+		let voucher_quantity = contribution
 			.checked_div(U256::from(voucher_price))
 			.ok_or("Voucher price must be greater than 0")?;
-		let voucher_supply_after: u128 = voucher_supply_after.saturated_into();
+		let voucher_quantity: Balance = voucher_quantity.saturated_into();
 
-		// Limit the voucher supply to the total supply in the case where voucher_price
-		// is inaccurate. This ensures we will never payout more than the total supply
-		let voucher_supply_after = u128::min(
-			voucher_supply_after,
-			voucher_max_supply.saturating_mul(10_u128.pow(VOUCHER_DECIMALS as u32)),
-		);
-
-		// Return the number of vouchers to be paid out, which is the difference between
-		// the total supply after this payment and the total supply before this payment
-		return Ok(voucher_supply_after.saturating_sub(voucher_current_supply))
+		Ok(voucher_quantity)
 	}
 
 	// Transfers vouchers from the vault account into a users wallet and returns the amount minted.
 	pub fn transfer_user_vouchers(
 		who: T::AccountId,
-		sale_id: SaleId,
 		sale_info: &SaleInformation<T::AccountId, T::BlockNumber>,
 		contribution: Balance,
 		voucher_max_supply: Balance,
-		voucher_current_supply: Balance,
-		total_paid_contributions: Balance,
 	) -> Result<Balance, DispatchError> {
 		// calculate the claimable vouchers
 		let claimable_vouchers = Self::calculate_voucher_rewards(
 			sale_info.soft_cap_price,
 			sale_info.funds_raised,
 			contribution.into(),
-			voucher_max_supply.into(),
-			voucher_current_supply,
-			total_paid_contributions.into(),
+			voucher_max_supply,
 		)
 		.map_err(|_| Error::<T>::VoucherClaimFailed)?;
+
+		let vault_balance =
+			T::MultiCurrency::reducible_balance(sale_info.voucher_asset_id, &sale_info.vault, false);
+		let vouchers = u128::min(vault_balance, claimable_vouchers);
 
 		// transfer claimable vouchers from vault account to the user
 		T::MultiCurrency::transfer(
 			sale_info.voucher_asset_id,
 			&sale_info.vault,
 			&who,
-			claimable_vouchers,
+			vouchers,
 			false,
 		)?;
 
@@ -238,7 +162,6 @@ impl<T: Config> Pallet<T> {
 					// Refunded amount is equal to the total issuance minus the total vouchers paid
 					// out Total vouchers paid out is the total funds raised divided by the voucher
 					// price
-					// TODO Verify this calculation
 					let voucher_total_issuance =
 						collection_max_issuance.saturating_mul(10u128.pow(VOUCHER_DECIMALS as u32));
 					let voucher_price = sale_info.soft_cap_price;
@@ -259,7 +182,7 @@ impl<T: Config> Pallet<T> {
 
 				if sale_info.funds_raised.is_zero() {
 					// No funds raised, end the sale now and skip distribution step
-					sale_info.status = SaleStatus::Ended(now, Balance::default());
+					sale_info.status = SaleStatus::Ended(now);
 				} else {
 					// Mark the sale for distribution
 					// Try append to distributingSales, if this fails due to upper vec bounds
@@ -269,8 +192,7 @@ impl<T: Config> Pallet<T> {
 						log!(error, "⛔️ failed to mark sale {:?} for distribution", sale_id);
 						return Ok(())
 					}
-					sale_info.status =
-						SaleStatus::Distributing(now, Balance::default(), Balance::default());
+					sale_info.status = SaleStatus::Distributing(now, Balance::default());
 				}
 
 				// Emit event to mark end of crowdsale

--- a/pallet/crowdsale/src/lib.rs
+++ b/pallet/crowdsale/src/lib.rs
@@ -31,7 +31,7 @@ use frame_support::{
 		traits::{AccountIdConversion, Zero},
 		SaturatedConversion, Saturating,
 	},
-	traits::fungibles::{self, Mutate, Transfer},
+	traits::fungibles::{self, Inspect, Mutate, Transfer},
 	transactional, PalletId,
 };
 use frame_system::{
@@ -41,7 +41,6 @@ use frame_system::{
 use seed_pallet_common::{log, CreateExt, InspectExt, NFTExt};
 use seed_primitives::{AssetId, Balance, CollectionUuid, OffchainErr, TokenCount};
 use sp_std::{vec, vec::Vec};
-use frame_support::traits::fungibles::Inspect;
 
 pub mod types;
 use types::*;
@@ -560,8 +559,11 @@ pub mod pallet {
 			if payout_complete || SaleParticipation::<T>::iter_prefix(sale_id).next().is_none() {
 				// Distribution complete
 				// Refund admin any remaining vouchers in the vault account
-				let vault_balance =
-					T::MultiCurrency::reducible_balance(sale_info.voucher_asset_id, &sale_info.vault, false);
+				let vault_balance = T::MultiCurrency::reducible_balance(
+					sale_info.voucher_asset_id,
+					&sale_info.vault,
+					false,
+				);
 				if vault_balance > 0 {
 					let _ = T::MultiCurrency::transfer(
 						sale_info.voucher_asset_id,
@@ -580,10 +582,7 @@ pub mod pallet {
 				SaleDistribution::<T>::put(BoundedVec::truncate_from(sale_ids));
 			} else {
 				// Update total_contributions
-				sale_info.status = SaleStatus::Distributing(
-					block_number,
-					vouchers_distributed,
-				);
+				sale_info.status = SaleStatus::Distributing(block_number, vouchers_distributed);
 			}
 
 			let next_unsigned_at = block_number + T::UnsignedInterval::get();
@@ -647,8 +646,11 @@ pub mod pallet {
 				if SaleParticipation::<T>::iter_prefix(sale_id).next().is_none() {
 					// Distribution complete
 					// Refund admin any remaining vouchers in the vault account
-					let vault_balance =
-						T::MultiCurrency::reducible_balance(sale_info.voucher_asset_id, &sale_info.vault, false);
+					let vault_balance = T::MultiCurrency::reducible_balance(
+						sale_info.voucher_asset_id,
+						&sale_info.vault,
+						false,
+					);
 					if vault_balance > 0 {
 						let _ = T::MultiCurrency::transfer(
 							sale_info.voucher_asset_id,
@@ -670,10 +672,7 @@ pub mod pallet {
 					});
 				} else {
 					// Update total_contributions
-					sale_info.status = SaleStatus::Distributing(
-						block_number,
-						vouchers_distributed,
-					);
+					sale_info.status = SaleStatus::Distributing(block_number, vouchers_distributed);
 				}
 
 				Self::deposit_event(Event::CrowdsaleVouchersClaimed {
@@ -772,10 +771,7 @@ pub mod pallet {
 					sale_info.status = SaleStatus::Ended(block_number);
 				} else {
 					// Mark the sale for distribution
-					sale_info.status = SaleStatus::Distributing(
-						block_number,
-						Balance::default(),
-					);
+					sale_info.status = SaleStatus::Distributing(block_number, Balance::default());
 				}
 
 				Self::deposit_event(Event::CrowdsaleManualDistribution {

--- a/pallet/crowdsale/src/lib.rs
+++ b/pallet/crowdsale/src/lib.rs
@@ -41,6 +41,7 @@ use frame_system::{
 use seed_pallet_common::{log, CreateExt, InspectExt, NFTExt};
 use seed_primitives::{AssetId, Balance, CollectionUuid, OffchainErr, TokenCount};
 use sp_std::{vec, vec::Vec};
+use frame_support::traits::fungibles::Inspect;
 
 pub mod types;
 use types::*;
@@ -512,7 +513,7 @@ pub mod pallet {
 			let mut sale_info = SaleInfo::<T>::get(sale_id).ok_or(Error::<T>::CrowdsaleNotFound)?;
 
 			// ensure the sale is in the distribution phase
-			let SaleStatus::Distributing(_, mut total_paid_contributions, mut vouchers_distributed) = sale_info.status else {
+			let SaleStatus::Distributing(_, mut vouchers_distributed) = sale_info.status else {
 				return Err(Error::<T>::InvalidCrowdsaleStatus.into());
 			};
 
@@ -533,12 +534,9 @@ pub mod pallet {
 
 				let Ok(claimable_vouchers) = Self::transfer_user_vouchers(
 					who.clone(),
-					sale_id,
 					&sale_info,
 					contribution.into(),
 					voucher_max_supply.into(),
-					vouchers_distributed,
-					total_paid_contributions.into(),
 				) else {
 					log!(
 						error,
@@ -556,13 +554,24 @@ pub mod pallet {
 				});
 
 				vouchers_distributed = vouchers_distributed.saturating_add(claimable_vouchers);
-				total_paid_contributions = total_paid_contributions.saturating_add(contribution);
 			}
 
 			let block_number = <frame_system::Pallet<T>>::block_number();
 			if payout_complete || SaleParticipation::<T>::iter_prefix(sale_id).next().is_none() {
 				// Distribution complete
-				sale_info.status = SaleStatus::Ended(block_number, vouchers_distributed);
+				// Refund admin any remaining vouchers in the vault account
+				let vault_balance =
+					T::MultiCurrency::reducible_balance(sale_info.voucher_asset_id, &sale_info.vault, false);
+				if vault_balance > 0 {
+					let _ = T::MultiCurrency::transfer(
+						sale_info.voucher_asset_id,
+						&sale_info.vault,
+						&sale_info.admin,
+						vault_balance,
+						false,
+					);
+				}
+				sale_info.status = SaleStatus::Ended(block_number);
 				Self::deposit_event(Event::CrowdsaleDistributionComplete {
 					sale_id,
 					vouchers_distributed,
@@ -573,7 +582,6 @@ pub mod pallet {
 				// Update total_contributions
 				sale_info.status = SaleStatus::Distributing(
 					block_number,
-					total_paid_contributions,
 					vouchers_distributed,
 				);
 			}
@@ -602,7 +610,7 @@ pub mod pallet {
 				let sale_info = sale_info.as_mut().ok_or(Error::<T>::CrowdsaleNotFound)?;
 
 				// ensure the sale is in the distribution phase
-				let SaleStatus::Distributing(_, total_paid_contributions, vouchers_distributed) = sale_info.status else {
+				let SaleStatus::Distributing(_, vouchers_distributed) = sale_info.status else {
 					return Err(Error::<T>::InvalidCrowdsaleStatus.into());
 				};
 
@@ -619,12 +627,9 @@ pub mod pallet {
 				// calculate the claimable vouchers
 				let claimable_vouchers = Self::transfer_user_vouchers(
 					who.clone(),
-					sale_id,
 					sale_info,
 					contribution.into(),
 					voucher_max_supply.into(),
-					vouchers_distributed,
-					total_paid_contributions.into(),
 				)
 				.map_err(|_| {
 					log!(
@@ -641,16 +646,32 @@ pub mod pallet {
 				// Check if we have any more payments to make
 				if SaleParticipation::<T>::iter_prefix(sale_id).next().is_none() {
 					// Distribution complete
-					sale_info.status = SaleStatus::Ended(block_number, vouchers_distributed);
+					// Refund admin any remaining vouchers in the vault account
+					let vault_balance =
+						T::MultiCurrency::reducible_balance(sale_info.voucher_asset_id, &sale_info.vault, false);
+					if vault_balance > 0 {
+						let _ = T::MultiCurrency::transfer(
+							sale_info.voucher_asset_id,
+							&sale_info.vault,
+							&sale_info.admin,
+							vault_balance,
+							false,
+						);
+					}
+					sale_info.status = SaleStatus::Ended(block_number);
 					Self::deposit_event(Event::CrowdsaleDistributionComplete {
 						sale_id,
 						vouchers_distributed,
+					});
+					// Clear SaleDistribution storage vec
+					let _ = SaleDistribution::<T>::try_mutate(|sales| -> DispatchResult {
+						sales.retain(|&id| id != sale_id);
+						Ok(())
 					});
 				} else {
 					// Update total_contributions
 					sale_info.status = SaleStatus::Distributing(
 						block_number,
-						total_paid_contributions.saturating_add(contribution),
 						vouchers_distributed,
 					);
 				}
@@ -692,8 +713,8 @@ pub mod pallet {
 
 				// ensure the sale has concluded and is being distributed or has been distributed
 				ensure!(
-					matches!(sale_info.status, SaleStatus::Distributing(_, _, _)) ||
-						matches!(sale_info.status, SaleStatus::Ended(_, _)),
+					matches!(sale_info.status, SaleStatus::Distributing(_, _)) ||
+						matches!(sale_info.status, SaleStatus::Ended(_)),
 					Error::<T>::InvalidCrowdsaleStatus
 				);
 
@@ -748,12 +769,11 @@ pub mod pallet {
 
 				let block_number = <frame_system::Pallet<T>>::block_number();
 				if sale_info.funds_raised.is_zero() {
-					sale_info.status = SaleStatus::Ended(block_number, Balance::default());
+					sale_info.status = SaleStatus::Ended(block_number);
 				} else {
 					// Mark the sale for distribution
 					sale_info.status = SaleStatus::Distributing(
 						block_number,
-						Balance::default(),
 						Balance::default(),
 					);
 				}

--- a/pallet/crowdsale/src/tests.rs
+++ b/pallet/crowdsale/src/tests.rs
@@ -46,13 +46,14 @@ fn create_nft_collection(owner: AccountId, max_issuance: TokenCount) -> Collecti
 	collection_id
 }
 
+// Helper function to initialize a crowdsale with default values
 fn initialize_crowdsale(
 	max_issuance: Balance,
 ) -> (SaleId, SaleInformation<AccountId, BlockNumber>) {
 	initialize_crowdsale_with_soft_cap(max_issuance, 10)
 }
 
-// Helper function ton initialize a crowdsale with default values
+// Helper function to initialize a crowdsale with specified soft_cap and max_issuance
 fn initialize_crowdsale_with_soft_cap(
 	max_issuance: Balance,
 	soft_cap_price: Balance,

--- a/pallet/crowdsale/src/tests.rs
+++ b/pallet/crowdsale/src/tests.rs
@@ -46,7 +46,9 @@ fn create_nft_collection(owner: AccountId, max_issuance: TokenCount) -> Collecti
 	collection_id
 }
 
-fn initialize_crowdsale(max_issuance: Balance)  -> (SaleId, SaleInformation<AccountId, BlockNumber>) {
+fn initialize_crowdsale(
+	max_issuance: Balance,
+) -> (SaleId, SaleInformation<AccountId, BlockNumber>) {
 	initialize_crowdsale_with_soft_cap(max_issuance, 10)
 }
 
@@ -339,29 +341,6 @@ mod calculate_voucher_rewards {
 					voucher_total_supply,
 				),
 				"Voucher price must be greater than 0"
-			);
-		});
-	}
-
-	#[test]
-	fn zero_total_supply() {
-		TestExt::<Test>::default().build().execute_with(|| {
-			let decimals = 6;
-			let soft_cap_price = add_decimals(1, decimals);
-			let voucher_total_supply = 0;
-			let total_raised = soft_cap_price;
-			let contribution = soft_cap_price;
-
-			// Although this should never happen, in the case where total supply is zero
-			// we should expect 0 to be paid out
-			assert_err!(
-				Pallet::<Test>::calculate_voucher_rewards(
-					soft_cap_price,
-					total_raised,
-					contribution.into(),
-					voucher_total_supply,
-				),
-				"Voucher max supply must be greater than 0"
 			);
 		});
 	}
@@ -1387,10 +1366,7 @@ mod claim_voucher {
 
 				// Check sale_info.status still distributing
 				let sale_info = SaleInfo::<Test>::get(sale_id).unwrap();
-				assert_eq!(
-					sale_info.status,
-					SaleStatus::Distributing(end_block, bob_balance)
-				);
+				assert_eq!(sale_info.status, SaleStatus::Distributing(end_block, bob_balance));
 
 				// Manual claim Charlie
 				assert_ok!(Crowdsale::claim_voucher(Some(charlie()).into(), sale_id));
@@ -1582,7 +1558,7 @@ mod claim_voucher {
 				);
 
 				// Sanity check
-				sale_info.status = SaleStatus::Distributing(0,  0);
+				sale_info.status = SaleStatus::Distributing(0, 0);
 				SaleInfo::<Test>::insert(sale_id, sale_info);
 				assert_ok!(Crowdsale::claim_voucher(Some(bob()).into(), sale_id));
 			});
@@ -2228,7 +2204,8 @@ mod automatic_distribution {
 
 		TestExt::<Test>::default().with_balances(&accounts).build().execute_with(|| {
 			let max_issuance = 14;
-			let (sale_id, sale_info) = initialize_crowdsale_with_soft_cap(max_issuance, soft_cap_price);
+			let (sale_id, sale_info) =
+				initialize_crowdsale_with_soft_cap(max_issuance, soft_cap_price);
 			let voucher_asset_id = sale_info.voucher_asset_id;
 			assert_ok!(Crowdsale::enable(Some(alice()).into(), sale_id));
 
@@ -2253,7 +2230,8 @@ mod automatic_distribution {
 				assert_ok!(Crowdsale::distribute_crowdsale_rewards(None.into()));
 			}
 
-			// Check status of each individual account. Each account should have some voucher balance
+			// Check status of each individual account. Each account should have some voucher
+			// balance
 			for (account, _) in accounts.into_iter() {
 				let voucher_balance =
 					AssetsExt::reducible_balance(voucher_asset_id, &account, false);
@@ -2305,7 +2283,8 @@ mod automatic_distribution {
 
 			TestExt::<Test>::default().with_balances(&accounts).build().execute_with(|| {
 				let max_issuance = 14;
-				let (sale_id, sale_info) = initialize_crowdsale_with_soft_cap(max_issuance, soft_cap_price);
+				let (sale_id, sale_info) =
+					initialize_crowdsale_with_soft_cap(max_issuance, soft_cap_price);
 				let voucher_asset_id = sale_info.voucher_asset_id;
 				assert_ok!(Crowdsale::enable(Some(alice()).into(), sale_id));
 
@@ -2325,7 +2304,8 @@ mod automatic_distribution {
 					assert_ok!(Crowdsale::distribute_crowdsale_rewards(None.into()));
 				}
 
-				// Check status of each individual account. Each account should have some voucher balance
+				// Check status of each individual account. Each account should have some voucher
+				// balance
 				for (account, _) in accounts.into_iter() {
 					let voucher_balance =
 						AssetsExt::reducible_balance(voucher_asset_id, &account, false);
@@ -2370,7 +2350,8 @@ mod automatic_distribution {
 
 			TestExt::<Test>::default().with_balances(&accounts).build().execute_with(|| {
 				let max_issuance = n;
-				let (sale_id, sale_info) = initialize_crowdsale_with_soft_cap(max_issuance, soft_cap_price);
+				let (sale_id, sale_info) =
+					initialize_crowdsale_with_soft_cap(max_issuance, soft_cap_price);
 				let voucher_asset_id = sale_info.voucher_asset_id;
 				assert_ok!(Crowdsale::enable(Some(alice()).into(), sale_id));
 
@@ -2390,7 +2371,8 @@ mod automatic_distribution {
 					assert_ok!(Crowdsale::distribute_crowdsale_rewards(None.into()));
 				}
 
-				// Check status of each individual account. Each account should have some voucher balance
+				// Check status of each individual account. Each account should have some voucher
+				// balance
 				for (account, _) in accounts.into_iter() {
 					let voucher_balance =
 						AssetsExt::reducible_balance(voucher_asset_id, &account, false);

--- a/pallet/crowdsale/src/types.rs
+++ b/pallet/crowdsale/src/types.rs
@@ -38,11 +38,10 @@ pub enum SaleStatus<BlockNumber> {
 	/// The sale has been started and is accepting contributions
 	Enabled(BlockNumber),
 	/// Distributing the rewards to participants,
-	/// (Total contributions paid out, total vouchers paid out)
-	Distributing(BlockNumber, Balance, Balance),
+	/// (Total vouchers paid out)
+	Distributing(BlockNumber, Balance),
 	/// The sale rewards have been distributed to participants
-	/// Balance represents total vouchers distributed
-	Ended(BlockNumber, Balance),
+	Ended(BlockNumber),
 	/// Distribution has not triggered automatically due to too much
 	/// Network traffic
 	DistributionFailed(BlockNumber),

--- a/pallet/crowdsale/src/types.rs
+++ b/pallet/crowdsale/src/types.rs
@@ -38,7 +38,7 @@ pub enum SaleStatus<BlockNumber> {
 	/// The sale has been started and is accepting contributions
 	Enabled(BlockNumber),
 	/// Distributing the rewards to participants,
-	/// (Total vouchers paid out)
+	/// Balance represents total vouchers paid out
 	Distributing(BlockNumber, Balance),
 	/// The sale rewards have been distributed to participants
 	Ended(BlockNumber),


### PR DESCRIPTION
Remove the over complicated calculations in favour of the simple calculations with extra precautions to deal with rounding issues. 
Refunds any remainder back to the admin at the end of the sale if there is leftovers due to rounding
Ensures payment never exceeds the vault balance to prevent failures 