### PR TITLE
Release/5.52.0

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -40,8 +40,8 @@ env:
 
 jobs:
   build-image:
-    # only run if release branch CI build passes or its a push to release branch
-    if: github.event.workflow_run.conclusion == 'success' || contains(github.ref_name, 'release')
+    # only run if release branch CI build passes or its a push to main branch
+    if: github.event.workflow_run.conclusion == 'success' || contains(github.ref_name, 'main') || contains(github.ref_name, 'release')
     runs-on: [seed-builder]
     permissions:
       contents: read

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -40,8 +40,8 @@ env:
 
 jobs:
   build-image:
-    # only run if release branch CI build passes or its a push to main branch
-    if: github.event.workflow_run.conclusion == 'success' || contains(github.ref_name, 'main') || contains(github.ref_name, 'release')
+    # only run if release branch CI build passes or its a push to release branch
+    if: github.event.workflow_run.conclusion == 'success' || contains(github.ref_name, 'release')
     runs-on: [seed-builder]
     permissions:
       contents: read
@@ -128,7 +128,7 @@ jobs:
   build-porcini-fork-image:
     needs: build-image
     if: github.event.workflow_run.conclusion == 'success' || contains(github.ref_name, 'release')
-    # only run if release branch CI build passes
+    runs-on: [seed-builder]
     permissions:
       contents: read
       packages: write

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -156,7 +156,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_version: 52,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
-	transaction_version: 6,
+	transaction_version: 7,
 	state_version: 0,
 };
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -153,7 +153,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("root"),
 	impl_name: create_runtime_str!("root"),
 	authoring_version: 1,
-	spec_version: 51,
+	spec_version: 52,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 6,


### PR DESCRIPTION
# Release

**Release Name:** `5.52.0`

**Spec Version:** `52`

**Client Version:** `5.0.0`

## Key Changes:

This release introduces the following changes:

- Adds a total contributors parameter to the SaleInfo Struct within pallet-crowdsale that keeps track of total unique contributors
- Adds fix that disallows public mint enabled collections to be crowdsale initialised
- Adds `proxy_vault_call` extrinsic to crowdsale pallet which allows admin access to NFT collection info
- Adds optional parameters to set custom name and symbol to voucher asset when initialising crowdsale

## PRs included:
- https://github.com/futureversecom/trn-seed/pull/814
- https://github.com/futureversecom/trn-seed/pull/815
- https://github.com/futureversecom/trn-seed/pull/818

---

## Client Changes:
- [ ] Yes
- [x] No


## Runtime Changes:
- [x] Yes
- [ ] No

### Storage Changes:
#### Changed:
 - crowdsale sale_info added participant_count field
 
### Extrinsic Changes:
#### Added:
- crowdsale.proxy_vault_call
#### Changed:
- crowdsale.initialize: added voucher_name and voucher_symbol optional parameters

### Event Changes:
#### Added:
- crowdsale.VaultCallProxied

### Error Messages:
#### Added:
- crowdsale.CollectionPublicMintable
- crowdsale.ExtrinsicForbidden

### Storage Migrations:
#### Added:
 - crowdsale SaleInfo translate + participant_count addition
#### Removed:
