### PR TITLE
Fix to dry out ethy old messages and improvements

### DIFF
--- a/ethy-gadget/src/gossip.rs
+++ b/ethy-gadget/src/gossip.rs
@@ -43,7 +43,7 @@ const MAX_COMPLETE_EVENT_CACHE: usize = 500;
 const REBROADCAST_AFTER: Duration = Duration::from_secs(60 * 5);
 
 // Event ids below this number will be discarded.
-const EVENT_INVALID_BELOW: u64 = 5674;
+const EVENT_INVALID_BELOW: u64 = 5683;
 
 /// ETHY gossip validator
 ///
@@ -159,7 +159,7 @@ where
 
 				trace!(target: "ethy", "💎 valid witness: {:?}, event: {:?}", &authority_id, event_id);
 				if event_id < EVENT_INVALID_BELOW {
-					info!(target: "ethy", "💎 witness: {:?}, event: {:?} sender: {:?} out of valid window. marked as discard.", &authority_id, event_id, sender);
+					info!(target: "ethy", "💎 witness: {:?}, event: {:?} sender: {:?} is marked as discard.", &authority_id, event_id, sender);
 					self.mark_complete(event_id);
 					return ValidationResult::Discard
 				}
@@ -184,7 +184,7 @@ where
 			};
 
 			if witness.event_id < EVENT_INVALID_BELOW {
-				debug!(target: "ethy", "💎 Message for event #{} is out of valid window. marked as expired: {}", witness.event_id, true);
+				debug!(target: "ethy", "💎 Message for event #{} is marked as expired: {}", witness.event_id, true);
 				self.mark_complete(witness.event_id);
 				return true
 			}
@@ -223,7 +223,7 @@ where
 			};
 
 			if witness.event_id < EVENT_INVALID_BELOW {
-				debug!(target: "ethy", "💎 Message for event #{} is out of valid window. marked as allowed: {}", witness.event_id, false);
+				debug!(target: "ethy", "💎 Message for event #{} is marked as allowed: {}", witness.event_id, false);
 				self.mark_complete(witness.event_id);
 				return false
 			}

--- a/ethy-gadget/src/gossip.rs
+++ b/ethy-gadget/src/gossip.rs
@@ -163,7 +163,7 @@ where
 				trace!(target: "ethy", "💎 valid witness: {:?}, event: {:?}", &authority_id, event_id);
 				if event_id < EVENT_INVALID_BELOW {
 					info!(target: "ethy", "💎 witness: {:?}, event: {:?} sender: {:?} is marked as discard.", &authority_id, event_id, sender);
-					self.mark_complete(event_id);
+					// self.mark_complete(event_id);
 					return ValidationResult::Discard
 				}
 
@@ -188,7 +188,7 @@ where
 
 			if witness.event_id < EVENT_INVALID_BELOW {
 				debug!(target: "ethy", "💎 Message for event #{} is marked as expired: {}", witness.event_id, true);
-				self.mark_complete(witness.event_id);
+				// self.mark_complete(witness.event_id);
 				return true
 			}
 
@@ -227,7 +227,7 @@ where
 
 			if witness.event_id < EVENT_INVALID_BELOW {
 				debug!(target: "ethy", "💎 Message for event #{} is marked as allowed: {}", witness.event_id, false);
-				self.mark_complete(witness.event_id);
+				// self.mark_complete(witness.event_id);
 				return false
 			}
 			// Check if message is incomplete

--- a/ethy-gadget/src/witness_record.rs
+++ b/ethy-gadget/src/witness_record.rs
@@ -129,7 +129,7 @@ impl WitnessRecord {
 		}
 		.unwrap_or(0_usize);
 
-		trace!(target: "ethy", "💎 event {:?}, has # support: {:?}", event_id, witness_count);
+		trace!(target: "ethy", "💎 event {:?}, has # support: {:?}, proof threshold: {:?}", event_id, witness_count, proof_threshold);
 		witness_count >= proof_threshold
 	}
 
@@ -291,7 +291,7 @@ fn compact_sequence(completed_events: &mut [EventProofId]) -> &[EventProofId] {
 			watermark_idx = i + 1;
 			continue
 		} else {
-			break
+			break // Note - fix the algo
 		}
 	}
 


### PR DESCRIPTION
### Changelog
- We add `EVENT_INVALID_BELOW` to discard old messages lesser than that.
- remove duplicate gossips of witneses by validators
- fixes in gossip validator
- passive peers gossip only if they have received finality notification and hence metadata. 
