### PR TITLE
Release/6.52.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1789,13 +1789,13 @@ dependencies = [
 
 [[package]]
 name = "ethy-gadget"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "ethabi",
  "futures",
  "futures-timer",
  "hex",
- "hex-literal 0.4.1",
+ "hex-literal",
  "libsecp256k1 0.6.0",
  "log",
  "parity-scale-codec",
@@ -2962,12 +2962,6 @@ name = "hex-literal"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ebdb29d2ea9ed0083cd8cece49bbd968021bd99b0849edb4a9a7ee0fdf6a4e0"
-
-[[package]]
-name = "hex-literal"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
 
 [[package]]
 name = "hex_fmt"
@@ -5170,7 +5164,7 @@ dependencies = [
  "frame-executive",
  "frame-support",
  "frame-system",
- "hex-literal 0.3.4",
+ "hex-literal",
  "pallet-assets",
  "pallet-assets-ext",
  "pallet-balances",
@@ -5256,7 +5250,7 @@ dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
- "hex-literal 0.3.4",
+ "hex-literal",
  "log",
  "pallet-assets",
  "pallet-assets-ext",
@@ -5309,7 +5303,7 @@ dependencies = [
  "frame-support",
  "frame-system",
  "hex",
- "hex-literal 0.3.4",
+ "hex-literal",
  "pallet-assets",
  "pallet-assets-ext",
  "pallet-balances",
@@ -5643,7 +5637,7 @@ dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
- "hex-literal 0.3.4",
+ "hex-literal",
  "pallet-assets",
  "pallet-assets-ext",
  "pallet-balances",
@@ -5673,7 +5667,7 @@ dependencies = [
  "frame-support",
  "frame-system",
  "hex",
- "hex-literal 0.3.4",
+ "hex-literal",
  "log",
  "pallet-assets",
  "pallet-assets-ext",
@@ -5845,7 +5839,7 @@ dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
- "hex-literal 0.3.4",
+ "hex-literal",
  "log",
  "pallet-assets",
  "pallet-assets-ext",
@@ -6157,7 +6151,7 @@ dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
- "hex-literal 0.3.4",
+ "hex-literal",
  "pallet-assets",
  "pallet-assets-ext",
  "pallet-balances",
@@ -6339,7 +6333,7 @@ dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
- "hex-literal 0.3.4",
+ "hex-literal",
  "log",
  "pallet-assets",
  "pallet-assets-ext",
@@ -6746,7 +6740,7 @@ dependencies = [
  "frame-support",
  "frame-system",
  "hex",
- "hex-literal 0.3.4",
+ "hex-literal",
  "impl-trait-for-tuples",
  "log",
  "num_enum",
@@ -8759,7 +8753,7 @@ dependencies = [
 
 [[package]]
 name = "seed-client"
-version = "5.0.0"
+version = "6.0.0"
 dependencies = [
  "clap",
  "ethy-gadget",
@@ -8778,7 +8772,7 @@ dependencies = [
  "frame-try-runtime",
  "futures",
  "hex",
- "hex-literal 0.3.4",
+ "hex-literal",
  "jsonrpsee",
  "libsecp256k1 0.6.0",
  "log",
@@ -8852,7 +8846,7 @@ dependencies = [
  "frame-support",
  "frame-system",
  "hex",
- "hex-literal 0.3.4",
+ "hex-literal",
  "impl-serde 0.4.0",
  "libsecp256k1 0.7.1",
  "log",
@@ -8893,7 +8887,7 @@ dependencies = [
  "frame-system-rpc-runtime-api",
  "frame-try-runtime",
  "hex",
- "hex-literal 0.3.4",
+ "hex-literal",
  "log",
  "pallet-assets",
  "pallet-assets-ext",

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "seed-client"
-version = "5.0.0"
+version = "6.0.0"
 authors = ["The Root Network Team"]
 edition = "2021"
 publish = false

--- a/ethy-gadget/Cargo.toml
+++ b/ethy-gadget/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethy-gadget"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Parity Technologies <admin@parity.io>", "The Root Network Team"]
 edition = "2021"
 license = "Apache-2.0"

--- a/ethy-gadget/src/gossip.rs
+++ b/ethy-gadget/src/gossip.rs
@@ -43,7 +43,7 @@ const MAX_COMPLETE_EVENT_CACHE: usize = 500;
 const REBROADCAST_AFTER: Duration = Duration::from_secs(60 * 5);
 
 // Event ids below this number will be discarded.
-const EVENT_INVALID_BELOW: u64 = 5674;
+const EVENT_INVALID_BELOW: u64 = 5683;
 
 /// ETHY gossip validator
 ///
@@ -159,7 +159,7 @@ where
 
 				trace!(target: "ethy", "💎 valid witness: {:?}, event: {:?}", &authority_id, event_id);
 				if event_id < EVENT_INVALID_BELOW {
-					info!(target: "ethy", "💎 witness: {:?}, event: {:?} sender: {:?} out of valid window. marked as discard.", &authority_id, event_id, sender);
+					info!(target: "ethy", "💎 witness: {:?}, event: {:?} sender: {:?} is marked as discard.", &authority_id, event_id, sender);
 					self.mark_complete(event_id);
 					return ValidationResult::Discard
 				}
@@ -184,7 +184,7 @@ where
 			};
 
 			if witness.event_id < EVENT_INVALID_BELOW {
-				debug!(target: "ethy", "💎 Message for event #{} is out of valid window. marked as expired: {}", witness.event_id, true);
+				debug!(target: "ethy", "💎 Message for event #{} is marked as expired: {}", witness.event_id, true);
 				self.mark_complete(witness.event_id);
 				return true
 			}
@@ -223,7 +223,7 @@ where
 			};
 
 			if witness.event_id < EVENT_INVALID_BELOW {
-				debug!(target: "ethy", "💎 Message for event #{} is out of valid window. marked as allowed: {}", witness.event_id, false);
+				debug!(target: "ethy", "💎 Message for event #{} is marked as allowed: {}", witness.event_id, false);
 				self.mark_complete(witness.event_id);
 				return false
 			}

--- a/ethy-gadget/src/gossip.rs
+++ b/ethy-gadget/src/gossip.rs
@@ -163,7 +163,7 @@ where
 				trace!(target: "ethy", "💎 valid witness: {:?}, event: {:?}", &authority_id, event_id);
 				if event_id < EVENT_INVALID_BELOW {
 					info!(target: "ethy", "💎 witness: {:?}, event: {:?} sender: {:?} is marked as discard.", &authority_id, event_id, sender);
-					self.mark_complete(event_id);
+					// self.mark_complete(event_id);
 					return ValidationResult::Discard
 				}
 
@@ -188,7 +188,7 @@ where
 
 			if witness.event_id < EVENT_INVALID_BELOW {
 				debug!(target: "ethy", "💎 Message for event #{} is marked as expired: {}", witness.event_id, true);
-				self.mark_complete(witness.event_id);
+				// self.mark_complete(witness.event_id);
 				return true
 			}
 
@@ -227,7 +227,7 @@ where
 
 			if witness.event_id < EVENT_INVALID_BELOW {
 				debug!(target: "ethy", "💎 Message for event #{} is marked as allowed: {}", witness.event_id, false);
-				self.mark_complete(witness.event_id);
+				// self.mark_complete(witness.event_id);
 				return false
 			}
 			// Check if message is incomplete

--- a/ethy-gadget/src/witness_record.rs
+++ b/ethy-gadget/src/witness_record.rs
@@ -129,7 +129,7 @@ impl WitnessRecord {
 		}
 		.unwrap_or(0_usize);
 
-		trace!(target: "ethy", "💎 event {:?}, has # support: {:?}", event_id, witness_count);
+		trace!(target: "ethy", "💎 event {:?}, has # support: {:?}, proof threshold: {:?}", event_id, witness_count, proof_threshold);
 		witness_count >= proof_threshold
 	}
 
@@ -291,7 +291,7 @@ fn compact_sequence(completed_events: &mut [EventProofId]) -> &[EventProofId] {
 			watermark_idx = i + 1;
 			continue
 		} else {
-			break
+			break // Note - fix the algo
 		}
 	}
 


### PR DESCRIPTION
# Release

**Release Name:** `6.52.0`

**Spec Version:** `52`

**Client Version:** `6.0.0`

## Key Changes:

This release includes fixes to discard old ethy messages and few improvements to the protocol

- Add `EVENT_INVALID_BELOW = 5683  to discard old messages lesser than that.
- remove duplicate gossips of witneses by validators
- fixes in gossip validator
- passive peers gossip only if they have received finality notification and hence the event metadata.

## PRs included:
---

## Client Changes:
- [x] Yes
- [ ] No


## Runtime Changes:
- [ ] Yes
- [x] No

### Storage Changes:
#### Changed:
 
### Extrinsic Changes:
#### Added:
#### Changed:

### Event Changes:
#### Added:

### Error Messages:
#### Added:

### Storage Migrations:
#### Added:
#### Removed:
