### PR TITLE
Deprecated EVM `callWithFeePreferences` function selector removal

### DIFF
--- a/e2e/common/index.ts
+++ b/e2e/common/index.ts
@@ -256,9 +256,6 @@ const OWNABLE_ABI = [
   "function transferOwnership(address owner)",
 ];
 
-export const FEE_PROXY_ABI_DEPRECATED = [
-  "function callWithFeePreferences(address asset, uint128 maxPayment, address target, bytes input)",
-];
 export const FEE_PROXY_ABI = ["function callWithFeePreferences(address asset, address target, bytes input)"];
 
 export const ERC20_ABI = [

--- a/evm-precompiles/utils/src/constants.rs
+++ b/evm-precompiles/utils/src/constants.rs
@@ -39,10 +39,6 @@ mod precompile_addresses {
 	/// The decoded location for the fee proxy function selector
 	/// 0x04BB = 00000100 10111011
 	pub const FEE_PROXY_ADDRESS: u64 = 1211; // 0x04BB
-	/// Function selector for call_with_fee_preferences (deprecated)
-	/// bytes4(keccak256(bytes("callWithFeePreferences(address,uint128,address,bytes)")));
-	#[deprecated(note = "Use `callWithFeePreferences(address,address,bytes)` instead")]
-	pub const FEE_FUNCTION_SELECTOR_DEPRECATED: [u8; 4] = [0x25, 0x5a, 0x34, 0x32];
 	/// Function selector for call_with_fee_preferences
 	/// bytes4(keccak256(bytes("callWithFeePreferences(address,address,bytes)")));
 	pub const FEE_FUNCTION_SELECTOR: [u8; 4] = [0xf6, 0x09, 0x82, 0x86];

--- a/pallet/fee-proxy/README.md
+++ b/pallet/fee-proxy/README.md
@@ -24,7 +24,8 @@ that the gas fees associated with an evm call are calculated outside of the weig
 itself. So in this case, the gas fees are calculated through `get_fee_preferences_data` (based on the
 gas_limit and max_fee_per_gas).
 
-## EVM based Multicurrency
+## EVM based Multicurrency - DEPRECATED; documentation requires update
+
 Multicurrency is also enabled for calls directly through our EVM. This is possible by wrapping an abi encoded input
 and setting the target to `FEE_PROXY_ADDRESS`. This is made possible by intercepting the implementation of `Runner` 
 defined in pallet_evm. By creating our own implementation with `FeePreferencesRunner` we are able to check the target 


### PR DESCRIPTION
## Changelog

Removes deprecated `function callWithFeePreferences(address asset, uint128 maxPayment, address target, bytes input)` function selector.
- Also removes respective tests (unit and e2e associated to this function selector)