### PR TITLE
Ethy gadget finalized block number based Witness pruning.

### DIFF
--- a/ethy-gadget/src/gossip.rs
+++ b/ethy-gadget/src/gossip.rs
@@ -41,7 +41,10 @@ where
 }
 
 /// Number of recent complete events to keep in memory
-const MAX_COMPLETE_EVENT_CACHE: usize = 30;
+// Theoretically This buffer should hold completed events until they go out of live window.
+// rough theoretical value of 2520 is suitable at the expense of increased search time. Should not
+// be problematic. can change as the network grows if required.
+const MAX_COMPLETE_EVENT_CACHE: usize = 500;
 
 // Timeout for rebroadcasting messages.
 const REBROADCAST_AFTER: Duration = Duration::from_secs(60 * 3);

--- a/ethy-gadget/src/lib.rs
+++ b/ethy-gadget/src/lib.rs
@@ -154,7 +154,7 @@ where
 	R: ProvideRuntimeApi<B>,
 	R::Api: EthyApi<B>,
 	N: GossipNetwork<B> + Clone + SyncOracle + Sync + Send + 'static,
-	<<B as BlockT>::Header as HeaderT>::Number: Into<u32>,
+	<<B as BlockT>::Header as HeaderT>::Number: Into<u64>,
 {
 	let EthyParams {
 		client,

--- a/ethy-gadget/src/lib.rs
+++ b/ethy-gadget/src/lib.rs
@@ -33,7 +33,7 @@ use sc_client_api::{Backend, BlockchainEvents, Finalizer};
 use sc_network::ProtocolName;
 use sc_network_gossip::{GossipEngine, Network as GossipNetwork};
 use seed_primitives::ethy::EthyApi;
-use sp_api::ProvideRuntimeApi;
+use sp_api::{BlockT, HeaderT, ProvideRuntimeApi};
 use sp_blockchain::HeaderBackend;
 use sp_consensus::SyncOracle;
 use sp_keystore::SyncCryptoStorePtr;
@@ -149,11 +149,12 @@ where
 pub async fn start_ethy_gadget<B, BE, C, R, N>(ethy_params: EthyParams<B, BE, C, R, N>)
 where
 	B: Block,
-	BE: Backend<B>,
+	BE: Backend<B> + 'static,
 	C: Client<B, BE>,
 	R: ProvideRuntimeApi<B>,
 	R::Api: EthyApi<B>,
 	N: GossipNetwork<B> + Clone + SyncOracle + Sync + Send + 'static,
+	<<B as BlockT>::Header as HeaderT>::Number: Into<u32>,
 {
 	let EthyParams {
 		client,
@@ -168,7 +169,8 @@ where
 	} = ethy_params;
 
 	let sync_oracle = network.clone();
-	let gossip_validator = Arc::new(gossip::GossipValidator::new(Default::default()));
+	let gossip_validator =
+		Arc::new(gossip::GossipValidator::new(Default::default(), backend.clone()));
 	let gossip_engine = GossipEngine::new(network, protocol_name, gossip_validator.clone(), None);
 
 	let metrics =

--- a/ethy-gadget/src/witness_record.rs
+++ b/ethy-gadget/src/witness_record.rs
@@ -129,7 +129,7 @@ impl WitnessRecord {
 		}
 		.unwrap_or(0_usize);
 
-		trace!(target: "ethy", "💎 event {:?}, has # support: {:?}", event_id, witness_count);
+		trace!(target: "ethy", "💎 event {:?}, has # support: {:?}, proof threshold: {:?}", event_id, witness_count, proof_threshold);
 		witness_count >= proof_threshold
 	}
 
@@ -291,7 +291,7 @@ fn compact_sequence(completed_events: &mut [EventProofId]) -> &[EventProofId] {
 			watermark_idx = i + 1;
 			continue
 		} else {
-			break
+			break // Note - fix the algo
 		}
 	}
 

--- a/ethy-gadget/src/witness_record.rs
+++ b/ethy-gadget/src/witness_record.rs
@@ -337,6 +337,7 @@ pub(crate) mod test {
 			validator_set_id: 5_u64,
 			authority_id: validator.public(),
 			signature: keystore.sign_prehashed(&validator.public(), &digest).unwrap(),
+			block_number: 0,
 		}
 	}
 

--- a/ethy-gadget/src/worker.rs
+++ b/ethy-gadget/src/worker.rs
@@ -325,9 +325,14 @@ where
 			return
 		}
 
+		// gossip the witness. will gossip even if we don't have event metadata yet. This would
+		// increase the network activity, but gives more room for validator Witnesses to spread
+		// across the network.
+		trace!(target: "ethy", "💎 gossiping witness: {:?}", witness.event_id);
 		self.gossip_engine.gossip_message(topic::<B>(), witness.encode(), false);
-		// after processing `witness` there may now be enough info to make a proof
-		self.try_make_proof(witness.event_id);
+
+		// Try to make proof
+		self.try_make_proof(witness.event_id.clone());
 	}
 
 	/// Try to make an event proof

--- a/ethy-gadget/src/worker.rs
+++ b/ethy-gadget/src/worker.rs
@@ -224,6 +224,7 @@ where
 				event_id,
 				authority_id: authority_id.clone(),
 				signature,
+				block_number: (*notification.header.number()).try_into().unwrap_or_default(),
 			};
 			let broadcast_witness = witness.encode();
 

--- a/ethy-gadget/src/worker.rs
+++ b/ethy-gadget/src/worker.rs
@@ -558,7 +558,8 @@ pub(crate) mod test {
 		let api = Arc::new(TestApi {});
 		let network = peer.network_service().clone();
 		let sync_oracle = network.clone();
-		let gossip_validator = Arc::new(crate::gossip::GossipValidator::new(validators));
+		let gossip_validator =
+			Arc::new(crate::gossip::GossipValidator::new(validators, peer.client().as_backend()));
 		let gossip_engine =
 			GossipEngine::new(network, ETHY_PROTOCOL_NAME, gossip_validator.clone(), None);
 		let (sender, _receiver) = NotificationStream::<_, EthyEventProofTracingKey>::channel();

--- a/ethy-gadget/src/worker.rs
+++ b/ethy-gadget/src/worker.rs
@@ -226,18 +226,13 @@ where
 				signature,
 				block_number: (*notification.header.number()).try_into().unwrap_or_default(),
 			};
-			let broadcast_witness = witness.encode();
 
 			metric_inc!(self, ethy_witness_sent);
-			debug!(target: "ethy", "💎 Sent witness: {:?}", witness);
 
 			// process the witness
 			self.witness_record.note_event_metadata(event_id, data, block, chain_id);
 			self.handle_witness(witness.clone());
-
-			// broadcast the witness
-			self.gossip_engine.gossip_message(topic::<B>(), broadcast_witness, false);
-			debug!(target: "ethy", "💎 gossiped witness for event: {:?}", witness.event_id);
+			debug!(target: "ethy", "💎 Sent witness: {:?}", witness);
 		}
 	}
 

--- a/primitives/src/ethy.rs
+++ b/primitives/src/ethy.rs
@@ -159,6 +159,8 @@ pub struct Witness {
 	pub authority_id: AuthorityId,
 	/// ECDSA signature over `digest`
 	pub signature: AuthoritySignature,
+	/// proof requested block number
+	pub block_number: u32
 }
 
 /// An Ethy event proof with validator signatures.

--- a/primitives/src/ethy.rs
+++ b/primitives/src/ethy.rs
@@ -160,7 +160,7 @@ pub struct Witness {
 	/// ECDSA signature over `digest`
 	pub signature: AuthoritySignature,
 	/// proof requested block number
-	pub block_number: u32
+	pub block_number: u32,
 }
 
 /// An Ethy event proof with validator signatures.

--- a/primitives/src/ethy.rs
+++ b/primitives/src/ethy.rs
@@ -160,7 +160,7 @@ pub struct Witness {
 	/// ECDSA signature over `digest`
 	pub signature: AuthoritySignature,
 	/// proof requested block number
-	pub block_number: u32,
+	pub block_number: u64,
 }
 
 /// An Ethy event proof with validator signatures.


### PR DESCRIPTION
### Changelog
 - Add `block_number` to `Witness`
 - Active validators now include finalized block number(that the proof request was made) in the Witness message
 - Define `WINDOW_SIZE = 90` or the live window, proof needs to be generated within this window. approximately ~6mins.
 - Update `GossipValidator` to include a reference to `Backend`
 - Any incoming Witness gossip messages that are outside the live window would be discarded.
 - change `REBROADCAST_AFTER` to 3 mins, allowing a second rebroadcast within the live window
 - Increase `MAX_COMPLETE_EVENT_CACHE` to 500
 
What we can expect with this change
- All the existing gossip Witness messages would be discarded due to the new format
- There is a chance of discarding witnesses before they can form the proof if goes out of the live window. we need a separate mechanism to handle these scenarios. will be introduced later.

Note - at post deployment, we need to make sure  at least 66% of the active validators are upgraded to the new image. otherwise could halt the proof formation due to not being able to reach consensus.
