### PR TITLE
Release 7.54.0

### DIFF
--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -153,10 +153,10 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("root"),
 	impl_name: create_runtime_str!("root"),
 	authoring_version: 1,
-	spec_version: 53,
+	spec_version: 54,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
-	transaction_version: 8,
+	transaction_version: 9,
 	state_version: 0,
 };
 


### PR DESCRIPTION
# Release

**Release Name:** `7.54.0`

**Spec Version:** `54`

**Client Version:** `7.0.0`

## Key Changes:

This release introduces the following changes:
- Fixes validator set issue on authorities change
- Fixes eth paused on authorities set change bug
- Optimises ethy on_initialise functionality
- Add benchmarks to Ethy pallet

## PRs included:
- https://github.com/futureversecom/trn-seed/pull/822
- https://github.com/futureversecom/trn-seed/pull/831

---

## Client Changes:
- [ ] Yes
- [x] No

## Runtime Changes:
- [x] Yes
- [ ] No

### Storage Changes:
#### Added:
- Ethy: MissedMessageIds, added to keep track of pruned, unprocessed messageIds
- Ethy: ProcessedMessageIds, changed to BoundedVec
#### Changed:
- Ethy.BridgePaused changed to new struct

### Extrinsic Changes:
#### Added:
- Ethy. submit_missing_event
- Ethy. remove_missing_event_id

### Event Changes:
#### Added:
- Ethy. MissingEventIdsRemoved

### Storage Migrations:
#### Added:
- Ethy migration for bridgepaused and processedMessageIds
