### PR TITLE
Add disable-eth-p2p flag to cli

### DIFF
--- a/client/src/cli.rs
+++ b/client/src/cli.rs
@@ -39,6 +39,11 @@ pub struct RunCmd {
 	// NOTE - check flags works as expected.
 	#[clap(long = "xrp-http")]
 	pub xrp_http: Option<String>,
+
+	/// Option to disable the eth p2p protocol
+	/// p2p protocol is enabled by default
+	#[clap(long = "disable-eth-p2p")]
+	pub disable_eth_p2p: bool,
 }
 
 #[derive(Debug, clap::Parser)]

--- a/client/src/cli.rs
+++ b/client/src/cli.rs
@@ -47,8 +47,6 @@ pub struct RunCmd {
 		long = "eth-p2p",
 		default_missing_value("true"),
 		default_value("true"),
-		num_args(0..=1),
-		require_equals(false),
 		action = ArgAction::Set,
 	)]
 	pub eth_p2p: bool,

--- a/client/src/cli.rs
+++ b/client/src/cli.rs
@@ -41,15 +41,15 @@ pub struct RunCmd {
 	#[clap(long = "xrp-http")]
 	pub xrp_http: Option<String>,
 
-	/// Option to disable the eth p2p protocol
+	/// Option to disable the ethy p2p protocol
 	/// p2p protocol is enabled by default
 	#[clap(
-		long = "eth-p2p",
+		long = "ethy-p2p",
 		default_missing_value("true"),
 		default_value("true"),
 		action = ArgAction::Set,
 	)]
-	pub eth_p2p: bool,
+	pub ethy_p2p: bool,
 }
 
 #[derive(Debug, clap::Parser)]

--- a/client/src/cli.rs
+++ b/client/src/cli.rs
@@ -14,6 +14,7 @@
 // You may obtain a copy of the License at the root of this project source code
 
 use crate::custom_commands::VerifyProofSigSubCommand;
+use clap::ArgAction;
 
 #[allow(missing_docs)]
 #[derive(Debug, clap::Parser)]
@@ -42,8 +43,15 @@ pub struct RunCmd {
 
 	/// Option to disable the eth p2p protocol
 	/// p2p protocol is enabled by default
-	#[clap(long = "disable-eth-p2p")]
-	pub disable_eth_p2p: bool,
+	#[clap(
+		long = "eth-p2p",
+		default_missing_value("true"),
+		default_value("true"),
+		num_args(0..=1),
+		require_equals(false),
+		action = ArgAction::Set,
+	)]
+	pub eth_p2p: bool,
 }
 
 #[derive(Debug, clap::Parser)]

--- a/client/src/service.rs
+++ b/client/src/service.rs
@@ -305,7 +305,7 @@ pub fn new_full(config: Configuration, cli: &Cli) -> Result<TaskManager, Service
 	// register ethy p2p protocol
 	let genesis_hash = client.block_hash(0).ok().flatten().expect("Genesis block exists; qed");
 	let ethy_protocol_name = ethy_gadget::protocol_standard_name(&genesis_hash, &config.chain_spec);
-	if !cli.run.disable_eth_p2p {
+	if cli.run.eth_p2p {
 		net_config.add_notification_protocol(ethy_gadget::ethy_peers_set_config(
 			ethy_protocol_name.clone(),
 		));
@@ -538,7 +538,7 @@ pub fn new_full(config: Configuration, cli: &Cli) -> Result<TaskManager, Service
 	// need a keystore, regardless of which protocol we use below.
 	let keystore = if role.is_authority() { Some(keystore_container.keystore()) } else { None };
 
-	if !cli.run.disable_eth_p2p {
+	if cli.run.eth_p2p {
 		let ethy_params = ethy_gadget::EthyParams {
 			client: client.clone(),
 			backend,

--- a/client/src/service.rs
+++ b/client/src/service.rs
@@ -303,7 +303,6 @@ pub fn new_full(config: Configuration, cli: &Cli) -> Result<TaskManager, Service
 	));
 
 	// register ethy p2p protocol
-	// TODO - add a command line option to toggle ethy p2p
 	let genesis_hash = client.block_hash(0).ok().flatten().expect("Genesis block exists; qed");
 	let ethy_protocol_name = ethy_gadget::protocol_standard_name(&genesis_hash, &config.chain_spec);
 	if !cli.run.disable_eth_p2p {

--- a/client/src/service.rs
+++ b/client/src/service.rs
@@ -305,7 +305,7 @@ pub fn new_full(config: Configuration, cli: &Cli) -> Result<TaskManager, Service
 	// register ethy p2p protocol
 	let genesis_hash = client.block_hash(0).ok().flatten().expect("Genesis block exists; qed");
 	let ethy_protocol_name = ethy_gadget::protocol_standard_name(&genesis_hash, &config.chain_spec);
-	if cli.run.eth_p2p {
+	if cli.run.ethy_p2p {
 		net_config.add_notification_protocol(ethy_gadget::ethy_peers_set_config(
 			ethy_protocol_name.clone(),
 		));
@@ -538,7 +538,7 @@ pub fn new_full(config: Configuration, cli: &Cli) -> Result<TaskManager, Service
 	// need a keystore, regardless of which protocol we use below.
 	let keystore = if role.is_authority() { Some(keystore_container.keystore()) } else { None };
 
-	if cli.run.eth_p2p {
+	if cli.run.ethy_p2p {
 		let ethy_params = ethy_gadget::EthyParams {
 			client: client.clone(),
 			backend,


### PR DESCRIPTION
Addresses [this issue](https://futureverse.atlassian.net/jira/software/c/projects/SU10/boards/140?assignee=712020%3A0dfd76f4-81ca-4b67-9284-a23e6fdf63bf&selectedIssue=SU10-120)

Adds a CLI flag to disable-eth-p2p. Enabled by default to avoid needing to restart running nodes with this flag