### PR TITLE
Eth `BLOCK_GAS_LIMIT` Optimizations

### DIFF
--- a/e2e/test/Dex/Dex.TxCosts.test.ts
+++ b/e2e/test/Dex/Dex.TxCosts.test.ts
@@ -216,7 +216,7 @@ describe("Dex Gas Estimation", function () {
 
   after(async () => {
     saveTxGas(allCosts, "Dex/TxCosts.md", "Dex Precompiles");
-    saveTxFees(allTxFeeCosts, "Dex/TxCosts.md", "ERC20 Precompiles");
+    saveTxFees(allTxFeeCosts, "Dex/TxCosts.md", "Dex Precompiles");
     await node.stop();
   });
 

--- a/e2e/test/Dex/TxCosts.md
+++ b/e2e/test/Dex/TxCosts.md
@@ -2,10 +2,10 @@
 
 | Function Call            | Contract gas | Precompile gas | (Extrinsic fee/Gas price) |
 |:-------------------------|:------------:|:--------------:|:-------------------------:|
-| addLiquidity             |    198248    |     89797      |           52139           |
-| removeLiquidity          |    171138    |     69284      |           34620           |
-| swapExactTokensForTokens |    134389    |     52657      |           26392           |
-| swapTokensForExactTokens |    134532    |     53269      |           27375           |
+| addLiquidity             |    198248    |     89797      |           52137           |
+| removeLiquidity          |    171138    |     69284      |           34619           |
+| swapExactTokensForTokens |    134389    |     52657      |           26391           |
+| swapTokensForExactTokens |    134532    |     53269      |           27374           |
 | quote                    |    44688     |     22377      |             0             |
 | getAmountOut             |    44688     |     22423      |             0             |
 | getAmountsOut            |    120661    |     34893      |             0             |
@@ -16,7 +16,7 @@
 
 | Function Call            | Contract cost (Drops) | Precompile cost (Drops) | Extrinsic cost (Drops) |
 |:-------------------------|:---------------------:|:-----------------------:|:----------------------:|
-| addLiquidity             |        1341853        |         664167          |         391047         |
-| removeLiquidity          |        1074942        |         481791          |         259655         |
-| swapExactTokensForTokens |        971294         |         390258          |         197944         |
-| swapTokensForExactTokens |        972456         |         396791          |         205317         |
+| addLiquidity             |        1341853        |         664167          |         391030         |
+| removeLiquidity          |        1074942        |         481791          |         259644         |
+| swapExactTokensForTokens |        971294         |         390258          |         197937         |
+| swapTokensForExactTokens |        972456         |         396791          |         205309         |

--- a/e2e/test/Dex/TxCosts.md
+++ b/e2e/test/Dex/TxCosts.md
@@ -2,21 +2,21 @@
 
 | Function Call            | Contract gas | Precompile gas | (Extrinsic fee/Gas price) |
 |:-------------------------|:------------:|:--------------:|:-------------------------:|
-| addLiquidity             |    197723    |     89078      |           52145           |
-| removeLiquidity          |    170713    |     68838      |           34641           |
-| swapExactTokensForTokens |    133986    |     52401      |           26421           |
-| swapTokensForExactTokens |    134130    |     53006      |           27404           |
+| addLiquidity             |    198248    |     89797      |           52139           |
+| removeLiquidity          |    171138    |     69284      |           34620           |
+| swapExactTokensForTokens |    134389    |     52657      |           26392           |
+| swapTokensForExactTokens |    134532    |     53269      |           27375           |
 | quote                    |    44688     |     22377      |             0             |
 | getAmountOut             |    44688     |     22423      |             0             |
-| getAmountsOut            |    120661    |     34806      |             0             |
-| getAmountsIn             |    120661    |     34799      |             0             |
+| getAmountsOut            |    120661    |     34893      |             0             |
+| getAmountsIn             |    120661    |     34886      |             0             |
 
 
 ## Generated tx costs(fees) for Dex Precompiles
 
 | Function Call            | Contract cost (Drops) | Precompile cost (Drops) | Extrinsic cost (Drops) |
 |:-------------------------|:---------------------:|:-----------------------:|:----------------------:|
-| addLiquidity             |        1338027        |         657776          |         391089         |
-| removeLiquidity          |        1072046        |         477830          |         259813         |
-| swapExactTokensForTokens |        968038         |         387534          |         198163         |
-| swapTokensForExactTokens |        969201         |         393986          |         205532         |
+| addLiquidity             |        1341853        |         664167          |         391047         |
+| removeLiquidity          |        1074942        |         481791          |         259655         |
+| swapExactTokensForTokens |        971294         |         390258          |         197944         |
+| swapTokensForExactTokens |        972456         |         396791          |         205317         |

--- a/e2e/test/Dex/TxCosts.md
+++ b/e2e/test/Dex/TxCosts.md
@@ -2,21 +2,21 @@
 
 | Function Call            | Contract gas | Precompile gas | (Extrinsic fee/Gas price) |
 |:-------------------------|:------------:|:--------------:|:-------------------------:|
-| addLiquidity             |    217853    |     122103     |           52139           |
-| removeLiquidity          |    183441    |     86009      |           34620           |
-| swapExactTokensForTokens |    150598    |     70507      |           26392           |
-| swapTokensForExactTokens |    150743    |     71568      |           27375           |
-| quote                    |    23716     |     22377      |             0             |
-| getAmountOut             |    26047     |     22447      |             0             |
-| getAmountsOut            |    43843     |     42619      |             0             |
-| getAmountsIn             |    44058     |     42611      |             0             |
+| addLiquidity             |    197723    |     89078      |           52145           |
+| removeLiquidity          |    170713    |     68838      |           34641           |
+| swapExactTokensForTokens |    133986    |     52401      |           26421           |
+| swapTokensForExactTokens |    134130    |     53006      |           27404           |
+| quote                    |    44688     |     22377      |             0             |
+| getAmountOut             |    44688     |     22423      |             0             |
+| getAmountsOut            |    120661    |     34806      |             0             |
+| getAmountsIn             |    120661    |     34799      |             0             |
 
 
-## Generated tx costs(fees) for ERC20 Precompiles
+## Generated tx costs(fees) for Dex Precompiles
 
 | Function Call            | Contract cost (Drops) | Precompile cost (Drops) | Extrinsic cost (Drops) |
 |:-------------------------|:---------------------:|:-----------------------:|:----------------------:|
-| addLiquidity             |        1484456        |         904088          |         391044         |
-| removeLiquidity          |        1182769        |         630493          |         259652         |
-| swapExactTokensForTokens |        1092758        |         492668          |         197943         |
-| swapTokensForExactTokens |        1093921        |         502105          |         205316         |
+| addLiquidity             |        1338027        |         657776          |         391089         |
+| removeLiquidity          |        1072046        |         477830          |         259813         |
+| swapExactTokensForTokens |        968038         |         387534          |         198163         |
+| swapTokensForExactTokens |        969201         |         393986          |         205532         |

--- a/e2e/test/ERC1155/TxCosts.md
+++ b/e2e/test/ERC1155/TxCosts.md
@@ -2,26 +2,26 @@
 
 | Function Call         | Contract gas | Precompile gas | (Extrinsic fee/Gas price) |
 |:----------------------|:------------:|:--------------:|:-------------------------:|
-| uri                   |    27560     |     22400      |             0             |
-| balanceOf             |    25957     |     22433      |             0             |
-| balanceOfBatch        |    32585     |     24106      |             0             |
-| setApprovalForAll     |    47025     |     27501      |             0             |
-| isApprovedForAll      |    26076     |     23184      |             0             |
-| safeTransferFrom      |    59163     |     32160      |           10552           |
-| safeBatchTransferFrom |    50205     |     35812      |           13298           |
-| mint                  |    33152     |     32245      |           11374           |
-| mintBatch             |    42210     |     32633      |           12307           |
-| burn                  |    32581     |     27608      |           9631            |
-| burnBatch             |    38043     |     31828      |           10564           |
+| uri                   |    27560     |     22376      |             0             |
+| balanceOf             |    25957     |     22408      |             0             |
+| balanceOfBatch        |    32585     |     23721      |             0             |
+| setApprovalForAll     |    47025     |     26235      |             0             |
+| isApprovedForAll      |    26076     |     22432      |             0             |
+| safeTransferFrom      |    74307     |     28882      |           10552           |
+| safeBatchTransferFrom |    75516     |     32822      |           13297           |
+| mint                  |    74473     |     28572      |           11373           |
+| mintBatch             |    75540     |     29371      |           12306           |
+| burn                  |    32581     |     26141      |           9630            |
+| burnBatch             |    38043     |     28466      |           10563           |
 
 
 ## Generated tx costs(fees) for ERC1155 Precompiles
 
 | Function Call         | Contract cost (Drops) | Precompile cost (Drops) | Extrinsic cost (Drops) |
 |:----------------------|:---------------------:|:-----------------------:|:----------------------:|
-| safeTransferFrom      |        440278         |         231113          |         79145          |
-| safeBatchTransferFrom |        364092         |         268013          |         99741          |
-| mint                  |        247001         |         232478          |         85307          |
-| mintBatch             |        294958         |         238690          |         92307          |
-| burn                  |        237850         |         203613          |         72233          |
-| burnBatch             |        284644         |         225810          |         79233          |
+| safeTransferFrom      |        440278         |         215285          |         79140          |
+| safeBatchTransferFrom |        364092         |         241713          |         99732          |
+| mint                  |        247001         |         214100          |         85301          |
+| mintBatch             |        294958         |         220311          |         92301          |
+| burn                  |        237850         |         189637          |         72228          |
+| burnBatch             |        284644         |         211834          |         79228          |

--- a/e2e/test/ERC1155/TxCosts.md
+++ b/e2e/test/ERC1155/TxCosts.md
@@ -11,7 +11,7 @@
 | safeBatchTransferFrom |    75516     |     32865      |           13298           |
 | mint                  |    74473     |     28847      |           11374           |
 | mintBatch             |    75540     |     31515      |           12307           |
-| burn                  |    32581     |     26154      |           9631            |
+| burn                  |    32581     |     26154      |           9630            |
 | burnBatch             |    38043     |     28483      |           10564           |
 
 
@@ -19,9 +19,9 @@
 
 | Function Call         | Contract cost (Drops) | Precompile cost (Drops) | Extrinsic cost (Drops) |
 |:----------------------|:---------------------:|:-----------------------:|:----------------------:|
-| safeTransferFrom      |        440278         |         215698          |         79145          |
-| safeBatchTransferFrom |        364092         |         242395          |         99741          |
-| mint                  |        247001         |         214572          |         85308          |
-| mintBatch             |        294958         |         220784          |         92308          |
-| burn                  |        237850         |         189997          |         72233          |
-| burnBatch             |        284644         |         212194          |         79233          |
+| safeTransferFrom      |        440278         |         215698          |         79144          |
+| safeBatchTransferFrom |        364092         |         242395          |         99740          |
+| mint                  |        247001         |         214572          |         85306          |
+| mintBatch             |        294958         |         220784          |         92306          |
+| burn                  |        237850         |         189997          |         72232          |
+| burnBatch             |        284644         |         212194          |         79232          |

--- a/e2e/test/ERC1155/TxCosts.md
+++ b/e2e/test/ERC1155/TxCosts.md
@@ -2,26 +2,26 @@
 
 | Function Call         | Contract gas | Precompile gas | (Extrinsic fee/Gas price) |
 |:----------------------|:------------:|:--------------:|:-------------------------:|
-| uri                   |    27560     |     22376      |             0             |
-| balanceOf             |    25957     |     22408      |             0             |
-| balanceOfBatch        |    32585     |     23721      |             0             |
-| setApprovalForAll     |    47025     |     26235      |             0             |
-| isApprovedForAll      |    26076     |     22432      |             0             |
-| safeTransferFrom      |    74307     |     28882      |           10552           |
-| safeBatchTransferFrom |    75516     |     32822      |           13297           |
-| mint                  |    74473     |     28572      |           11373           |
-| mintBatch             |    75540     |     29371      |           12306           |
-| burn                  |    32581     |     26141      |           9630            |
-| burnBatch             |    38043     |     28466      |           10563           |
+| uri                   |    27560     |     22377      |             0             |
+| balanceOf             |    25957     |     22409      |             0             |
+| balanceOfBatch        |    32585     |     23723      |             0             |
+| setApprovalForAll     |    47025     |     26244      |             0             |
+| isApprovedForAll      |    26076     |     22433      |             0             |
+| safeTransferFrom      |    74307     |     28902      |           10552           |
+| safeBatchTransferFrom |    75516     |     32865      |           13298           |
+| mint                  |    74473     |     28847      |           11374           |
+| mintBatch             |    75540     |     31515      |           12307           |
+| burn                  |    32581     |     26154      |           9631            |
+| burnBatch             |    38043     |     28483      |           10564           |
 
 
 ## Generated tx costs(fees) for ERC1155 Precompiles
 
 | Function Call         | Contract cost (Drops) | Precompile cost (Drops) | Extrinsic cost (Drops) |
 |:----------------------|:---------------------:|:-----------------------:|:----------------------:|
-| safeTransferFrom      |        440278         |         215285          |         79140          |
-| safeBatchTransferFrom |        364092         |         241713          |         99732          |
-| mint                  |        247001         |         214100          |         85301          |
-| mintBatch             |        294958         |         220311          |         92301          |
-| burn                  |        237850         |         189637          |         72228          |
-| burnBatch             |        284644         |         211834          |         79228          |
+| safeTransferFrom      |        440278         |         215698          |         79145          |
+| safeBatchTransferFrom |        364092         |         242395          |         99741          |
+| mint                  |        247001         |         214572          |         85308          |
+| mintBatch             |        294958         |         220784          |         92308          |
+| burn                  |        237850         |         189997          |         72233          |
+| burnBatch             |        284644         |         212194          |         79233          |

--- a/e2e/test/ERC20/TxCosts.md
+++ b/e2e/test/ERC20/TxCosts.md
@@ -6,7 +6,7 @@
 | balanceOf     |    25860     |     23694      |             0             |
 | allowance     |    26064     |     23273      |             0             |
 | approval      |    47152     |     26142      |           11782           |
-| transfer      |    52698     |     35599      |           15507           |
+| transfer      |    52698     |     35599      |           15506           |
 | transferFrom  |    44716     |     43768      |           18731           |
 | name          |    25926     |     22365      |             0             |
 | decimals      |    22354     |     22365      |             0             |
@@ -17,6 +17,6 @@
 
 | Function Call | Contract cost (Drops) | Precompile cost (Drops) | Extrinsic cost (Drops) |
 |:--------------|:---------------------:|:-----------------------:|:----------------------:|
-| approval      |        351452         |         189675          |         88370          |
-| transfer      |        390700         |         265015          |         116305         |
-| transferFrom  |        323614         |         312725          |         140488         |
+| approval      |        351452         |         189675          |         88368          |
+| transfer      |        390700         |         265015          |         116302         |
+| transferFrom  |        323614         |         312725          |         140484         |

--- a/e2e/test/ERC20/TxCosts.md
+++ b/e2e/test/ERC20/TxCosts.md
@@ -2,21 +2,21 @@
 
 | Function Call | Contract gas | Precompile gas | (Extrinsic fee/Gas price) |
 |:--------------|:------------:|:--------------:|:-------------------------:|
-| totalSupply   |    23717     |     22364      |             0             |
-| balanceOf     |    25860     |     23692      |             0             |
+| totalSupply   |    23717     |     22365      |             0             |
+| balanceOf     |    25860     |     23694      |             0             |
 | allowance     |    26064     |     23273      |             0             |
-| approval      |    47152     |     26133      |           11781           |
-| transfer      |    52698     |     35514      |           15505           |
-| transferFrom  |    44716     |     43610      |           18728           |
-| name          |    25926     |     22364      |             0             |
-| decimals      |    22354     |     22364      |             0             |
-| symbol        |    25945     |     22364      |             0             |
+| approval      |    47152     |     26142      |           11782           |
+| transfer      |    52698     |     35599      |           15507           |
+| transferFrom  |    44716     |     43768      |           18731           |
+| name          |    25926     |     22365      |             0             |
+| decimals      |    22354     |     22365      |             0             |
+| symbol        |    25945     |     22365      |             0             |
 
 
 ## Generated tx costs(fees) for ERC20 Precompiles
 
 | Function Call | Contract cost (Drops) | Precompile cost (Drops) | Extrinsic cost (Drops) |
 |:--------------|:---------------------:|:-----------------------:|:----------------------:|
-| approval      |        351452         |         189442          |         88360          |
-| transfer      |        390700         |         263777          |         116288         |
-| transferFrom  |        323614         |         310917          |         140466         |
+| approval      |        351452         |         189675          |         88370          |
+| transfer      |        390700         |         265015          |         116305         |
+| transferFrom  |        323614         |         312725          |         140488         |

--- a/e2e/test/ERC20/TxCosts.md
+++ b/e2e/test/ERC20/TxCosts.md
@@ -2,21 +2,21 @@
 
 | Function Call | Contract gas | Precompile gas | (Extrinsic fee/Gas price) |
 |:--------------|:------------:|:--------------:|:-------------------------:|
-| totalSupply   |    23717     |     22388      |             0             |
-| balanceOf     |    25860     |     23974      |             0             |
+| totalSupply   |    23717     |     22364      |             0             |
+| balanceOf     |    25860     |     23692      |             0             |
 | allowance     |    26064     |     23273      |             0             |
-| approval      |    47152     |     26470      |           11782           |
-| transfer      |    52698     |     43641      |           15507           |
-| transferFrom  |    44716     |     51726      |           18731           |
-| name          |    25926     |     22388      |             0             |
-| decimals      |    22354     |     22388      |             0             |
-| symbol        |    25945     |     22388      |             0             |
+| approval      |    47152     |     26133      |           11781           |
+| transfer      |    52698     |     35514      |           15505           |
+| transferFrom  |    44716     |     43610      |           18728           |
+| name          |    25926     |     22364      |             0             |
+| decimals      |    22354     |     22364      |             0             |
+| symbol        |    25945     |     22364      |             0             |
 
 
 ## Generated tx costs(fees) for ERC20 Precompiles
 
 | Function Call | Contract cost (Drops) | Precompile cost (Drops) | Extrinsic cost (Drops) |
 |:--------------|:---------------------:|:-----------------------:|:----------------------:|
-| approval      |        351452         |         198422          |         88369          |
-| transfer      |        390700         |         311427          |         116305         |
-| transferFrom  |        323614         |         380276          |         140487         |
+| approval      |        351452         |         189442          |         88360          |
+| transfer      |        390700         |         263777          |         116288         |
+| transferFrom  |        323614         |         310917          |         140466         |

--- a/e2e/test/ERC721/TxCosts.md
+++ b/e2e/test/ERC721/TxCosts.md
@@ -2,32 +2,32 @@
 
 | Function Call     | Contract gas | Precompile gas | (Extrinsic fee/Gas price) |
 |:------------------|:------------:|:--------------:|:-------------------------:|
-| balanceOf         |    25895     |     23274      |             0             |
-| ownerOf           |    25847     |     23242      |             0             |
-| getApproved       |    27395     |     23242      |             0             |
-| isApprovedForAll  |    26082     |     23973      |             0             |
-| mint              |    53193     |     31731      |           9216            |
-| burn              |    37870     |     35731      |           10523           |
-| approve           |    50740     |     28884      |           10852           |
-| setApprovalForAll |    47011     |     26467      |           9700            |
-| safetransferFrom  |    67181     |     36625      |             0             |
-| transferFrom      |    66839     |     35560      |           11585           |
-| name              |    25932     |     22388      |             0             |
-| symbol            |    25938     |     22388      |             0             |
-| tokenURI          |    25964     |     23242      |             0             |
-| owner             |    23728     |     22388      |             0             |
-| transferOwnership |    29147     |     28498      |           9501            |
-| renounceOwnership |    30272     |     28372      |           9455            |
+| balanceOf         |    25895     |     23238      |             0             |
+| ownerOf           |    25847     |     23206      |             0             |
+| getApproved       |    27395     |     23206      |             0             |
+| isApprovedForAll  |    26082     |     23733      |             0             |
+| mint              |    81095     |     27732      |           9216            |
+| burn              |    37870     |     32429      |           10522           |
+| approve           |    50740     |     27473      |           10851           |
+| setApprovalForAll |    47011     |     26130      |           9700            |
+| safetransferFrom  |    77443     |     32611      |             0             |
+| transferFrom      |    66839     |     32381      |           11584           |
+| name              |    25932     |     22364      |             0             |
+| symbol            |    25938     |     22364      |             0             |
+| tokenURI          |    25964     |     23206      |             0             |
+| owner             |    23728     |     22364      |             0             |
+| transferOwnership |    29147     |     27419      |           9501            |
+| renounceOwnership |    30272     |     26402      |           9454            |
 
 
 ## Generated tx costs(fees) for ERC721 Precompiles
 
 | Function Call     | Contract cost (Drops) | Precompile cost (Drops) | Extrinsic cost (Drops) |
 |:------------------|:---------------------:|:-----------------------:|:----------------------:|
-| mint              |        395981         |         224249          |         69126          |
-| burn              |        245366         |         266850          |         78929          |
-| approve           |        369808         |         215338          |         81394          |
-| setApprovalForAll |        349839         |         198339          |         72754          |
-| transferFrom      |        442288         |         264345          |         86893          |
-| transferOwnership |        218098         |         212502          |         71263          |
-| renounceOwnership |        176172         |         209831          |         70913          |
+| mint              |        395981         |         206426          |         69121          |
+| burn              |        245366         |         235419          |         78921          |
+| approve           |        369808         |         200507          |         81389          |
+| setApprovalForAll |        349839         |         189360          |         72751          |
+| transferFrom      |        442288         |         234646          |         86885          |
+| transferOwnership |        218098         |         199277          |         71258          |
+| renounceOwnership |        176172         |         196606          |         70908          |

--- a/e2e/test/ERC721/TxCosts.md
+++ b/e2e/test/ERC721/TxCosts.md
@@ -2,32 +2,32 @@
 
 | Function Call     | Contract gas | Precompile gas | (Extrinsic fee/Gas price) |
 |:------------------|:------------:|:--------------:|:-------------------------:|
-| balanceOf         |    25895     |     23238      |             0             |
-| ownerOf           |    25847     |     23206      |             0             |
-| getApproved       |    27395     |     23206      |             0             |
-| isApprovedForAll  |    26082     |     23733      |             0             |
-| mint              |    81095     |     27732      |           9216            |
-| burn              |    37870     |     32429      |           10522           |
-| approve           |    50740     |     27473      |           10851           |
-| setApprovalForAll |    47011     |     26130      |           9700            |
-| safetransferFrom  |    77443     |     32611      |             0             |
-| transferFrom      |    66839     |     32381      |           11584           |
-| name              |    25932     |     22364      |             0             |
-| symbol            |    25938     |     22364      |             0             |
-| tokenURI          |    25964     |     23206      |             0             |
-| owner             |    23728     |     22364      |             0             |
-| transferOwnership |    29147     |     27419      |           9501            |
-| renounceOwnership |    30272     |     26402      |           9454            |
+| balanceOf         |    25895     |     23239      |             0             |
+| ownerOf           |    25847     |     23207      |             0             |
+| getApproved       |    27395     |     23207      |             0             |
+| isApprovedForAll  |    26082     |     23734      |             0             |
+| mint              |    81095     |     27752      |           9216            |
+| burn              |    37870     |     32480      |           10524           |
+| approve           |    50740     |     27489      |           10852           |
+| setApprovalForAll |    47011     |     26139      |           9700            |
+| safetransferFrom  |    77443     |     32663      |             0             |
+| transferFrom      |    66839     |     32429      |           11585           |
+| name              |    25932     |     22365      |             0             |
+| symbol            |    25938     |     22365      |             0             |
+| tokenURI          |    25964     |     23207      |             0             |
+| owner             |    23728     |     22365      |             0             |
+| transferOwnership |    29147     |     27434      |           9501            |
+| renounceOwnership |    30272     |     26415      |           9455            |
 
 
 ## Generated tx costs(fees) for ERC721 Precompiles
 
 | Function Call     | Contract cost (Drops) | Precompile cost (Drops) | Extrinsic cost (Drops) |
 |:------------------|:---------------------:|:-----------------------:|:----------------------:|
-| mint              |        395981         |         206426          |         69121          |
-| burn              |        245366         |         235419          |         78921          |
-| approve           |        369808         |         200507          |         81389          |
-| setApprovalForAll |        349839         |         189360          |         72751          |
-| transferFrom      |        442288         |         234646          |         86885          |
-| transferOwnership |        218098         |         199277          |         71258          |
-| renounceOwnership |        176172         |         196606          |         70908          |
+| mint              |        395981         |         206891          |         69126          |
+| burn              |        245366         |         236244          |         78930          |
+| approve           |        369808         |         200890          |         81394          |
+| setApprovalForAll |        349839         |         189592          |         72754          |
+| transferFrom      |        442288         |         235419          |         86894          |
+| transferOwnership |        218098         |         199622          |         71263          |
+| renounceOwnership |        176172         |         196951          |         70913          |

--- a/e2e/test/ERC721/TxCosts.md
+++ b/e2e/test/ERC721/TxCosts.md
@@ -7,7 +7,7 @@
 | getApproved       |    27395     |     23207      |             0             |
 | isApprovedForAll  |    26082     |     23734      |             0             |
 | mint              |    81095     |     27752      |           9216            |
-| burn              |    37870     |     32480      |           10524           |
+| burn              |    37870     |     32480      |           10523           |
 | approve           |    50740     |     27489      |           10852           |
 | setApprovalForAll |    47011     |     26139      |           9700            |
 | safetransferFrom  |    77443     |     32663      |             0             |
@@ -17,17 +17,17 @@
 | tokenURI          |    25964     |     23207      |             0             |
 | owner             |    23728     |     22365      |             0             |
 | transferOwnership |    29147     |     27434      |           9501            |
-| renounceOwnership |    30272     |     26415      |           9455            |
+| renounceOwnership |    30272     |     26415      |           9454            |
 
 
 ## Generated tx costs(fees) for ERC721 Precompiles
 
 | Function Call     | Contract cost (Drops) | Precompile cost (Drops) | Extrinsic cost (Drops) |
 |:------------------|:---------------------:|:-----------------------:|:----------------------:|
-| mint              |        395981         |         206891          |         69126          |
-| burn              |        245366         |         236244          |         78930          |
-| approve           |        369808         |         200890          |         81394          |
+| mint              |        395981         |         206891          |         69125          |
+| burn              |        245366         |         236244          |         78928          |
+| approve           |        369808         |         200890          |         81393          |
 | setApprovalForAll |        349839         |         189592          |         72754          |
-| transferFrom      |        442288         |         235419          |         86894          |
-| transferOwnership |        218098         |         199622          |         71263          |
-| renounceOwnership |        176172         |         196951          |         70913          |
+| transferFrom      |        442288         |         235419          |         86892          |
+| transferOwnership |        218098         |         199622          |         71262          |
+| renounceOwnership |        176172         |         196951          |         70912          |

--- a/e2e/test/Futurepass/TxCosts.md
+++ b/e2e/test/Futurepass/TxCosts.md
@@ -2,19 +2,19 @@
 
 | Function Call                 | Contract gas | Precompile gas | (Extrinsic fee/Gas price) |
 |:------------------------------|:------------:|:--------------:|:-------------------------:|
-| create                        |      0       |     36968      |           16352           |
-| registerDelegateWithSignature |      0       |     38388      |           20188           |
-| unregisterDelegate            |      0       |     35481      |           16200           |
-| transferOwnership             |      0       |     43720      |           20407           |
-| proxyCall                     |      0       |     65259      |           21152           |
+| create                        |      0       |     37068      |           16355           |
+| registerDelegateWithSignature |      0       |     38495      |           20191           |
+| unregisterDelegate            |      0       |     35566      |           16203           |
+| transferOwnership             |      0       |     43883      |           20410           |
+| proxyCall                     |      0       |     65272      |           21155           |
 
 
 ## Generated tx costs(fees) for Futurepass Precompiles
 
 | Function Call                 | Contract cost (Drops) | Precompile cost (Drops) | Extrinsic cost (Drops) |
 |:------------------------------|:---------------------:|:-----------------------:|:----------------------:|
-| create                        |           0           |         274734          |         122645         |
-| registerDelegateWithSignature |           0           |         286864          |         151414         |
-| unregisterDelegate            |           0           |         263205          |         121506         |
-| transferOwnership             |           0           |         312227          |         153054         |
-| proxyCall                     |           0           |         446016          |         158642         |
+| create                        |           0           |         276130          |         122664         |
+| registerDelegateWithSignature |           0           |         288305          |         151433         |
+| unregisterDelegate            |           0           |         264442          |         121524         |
+| transferOwnership             |           0           |         314095          |         153081         |
+| proxyCall                     |           0           |         446121          |         158669         |

--- a/e2e/test/Futurepass/TxCosts.md
+++ b/e2e/test/Futurepass/TxCosts.md
@@ -2,19 +2,19 @@
 
 | Function Call                 | Contract gas | Precompile gas | (Extrinsic fee/Gas price) |
 |:------------------------------|:------------:|:--------------:|:-------------------------:|
-| create                        |      0       |     37068      |           16355           |
-| registerDelegateWithSignature |      0       |     38495      |           20191           |
-| unregisterDelegate            |      0       |     35566      |           16203           |
+| create                        |      0       |     37062      |           16354           |
+| registerDelegateWithSignature |      0       |     38495      |           20190           |
+| unregisterDelegate            |      0       |     35566      |           16202           |
 | transferOwnership             |      0       |     43883      |           20410           |
-| proxyCall                     |      0       |     65272      |           21155           |
+| proxyCall                     |      0       |     65262      |           21155           |
 
 
 ## Generated tx costs(fees) for Futurepass Precompiles
 
 | Function Call                 | Contract cost (Drops) | Precompile cost (Drops) | Extrinsic cost (Drops) |
 |:------------------------------|:---------------------:|:-----------------------:|:----------------------:|
-| create                        |           0           |         276130          |         122664         |
-| registerDelegateWithSignature |           0           |         288305          |         151433         |
-| unregisterDelegate            |           0           |         264442          |         121524         |
-| transferOwnership             |           0           |         314095          |         153081         |
-| proxyCall                     |           0           |         446121          |         158669         |
+| create                        |           0           |         276040          |         122660         |
+| registerDelegateWithSignature |           0           |         288305          |         151429         |
+| unregisterDelegate            |           0           |         264442          |         121520         |
+| transferOwnership             |           0           |         314095          |         153075         |
+| proxyCall                     |           0           |         446031          |         158664         |

--- a/e2e/test/Futurepass/TxCosts.md
+++ b/e2e/test/Futurepass/TxCosts.md
@@ -2,19 +2,19 @@
 
 | Function Call                 | Contract gas | Precompile gas | (Extrinsic fee/Gas price) |
 |:------------------------------|:------------:|:--------------:|:-------------------------:|
-| create                        |      0       |     45155      |           16355           |
-| registerDelegateWithSignature |      0       |     46056      |           20190           |
-| unregisterDelegate            |      0       |     43622      |           16203           |
-| transferOwnership             |      0       |     52086      |           20410           |
-| proxyCall                     |      0       |     65694      |           21155           |
+| create                        |      0       |     36968      |           16352           |
+| registerDelegateWithSignature |      0       |     38388      |           20188           |
+| unregisterDelegate            |      0       |     35481      |           16200           |
+| transferOwnership             |      0       |     43720      |           20407           |
+| proxyCall                     |      0       |     65259      |           21152           |
 
 
 ## Generated tx costs(fees) for Futurepass Precompiles
 
 | Function Call                 | Contract cost (Drops) | Precompile cost (Drops) | Extrinsic cost (Drops) |
 |:------------------------------|:---------------------:|:-----------------------:|:----------------------:|
-| create                        |           0           |         328633          |         122663         |
-| registerDelegateWithSignature |           0           |         338932          |         151432         |
-| unregisterDelegate            |           0           |         311102          |         121523         |
-| transferOwnership             |           0           |         384166          |         153079         |
-| proxyCall                     |           0           |         449872          |         158668         |
+| create                        |           0           |         274734          |         122645         |
+| registerDelegateWithSignature |           0           |         286864          |         151414         |
+| unregisterDelegate            |           0           |         263205          |         121506         |
+| transferOwnership             |           0           |         312227          |         153054         |
+| proxyCall                     |           0           |         446016          |         158642         |

--- a/e2e/test/MarketPlace/TxCosts.md
+++ b/e2e/test/MarketPlace/TxCosts.md
@@ -2,29 +2,29 @@
 
 | Function Call       | Contract gas | Precompile gas | (Extrinsic fee/Gas price) |
 |:--------------------|:------------:|:--------------:|:-------------------------:|
-| registerMarketplace |      0       |     32307      |           10843           |
-| sellNft             |      0       |     55445      |           22404           |
-| auctionNft          |      0       |     55709      |           21416           |
-| makeSimpleOffer     |      0       |     60972      |           37599           |
-| buy                 |      0       |     50424      |          151674           |
-| bid                 |      0       |     61632      |          1358014          |
-| cancelSale          |      0       |     38090      |           13321           |
-| updateFixedPrice    |      0       |     29163      |           9867            |
-| acceptOffer         |      0       |     74959      |           27394           |
-| cancelOffer         |      0       |     56308      |           20784           |
+| registerMarketplace |      0       |     28498      |           10842           |
+| sellNft             |      0       |     45446      |           22401           |
+| auctionNft          |      0       |     45520      |           21412           |
+| makeSimpleOffer     |      0       |     49759      |           37595           |
+| buy                 |      0       |     42648      |          151671           |
+| bid                 |      0       |     50132      |          1358010          |
+| cancelSale          |      0       |     33067      |           13319           |
+| updateFixedPrice    |      0       |     27583      |           9866            |
+| acceptOffer         |      0       |     55532      |           27388           |
+| cancelOffer         |      0       |     45476      |           20780           |
 
 
 ## Generated tx costs(fees) for Marketplace Precompiles
 
 | Function Call       | Contract cost (Drops) | Precompile cost (Drops) | Extrinsic cost (Drops) |
 |:--------------------|:---------------------:|:-----------------------:|:----------------------:|
-| registerMarketplace |           0           |         233484          |         81325          |
-| sellNft             |           0           |         408156          |         168036         |
-| auctionNft          |           0           |         410872          |         160620         |
-| makeSimpleOffer     |           0           |         555461          |         281997         |
-| buy                 |           0           |         1366440         |        1137559         |
-| bid                 |           0           |        10462114         |        10185109        |
-| cancelSale          |           0           |         285289          |         99912          |
-| updateFixedPrice    |           0           |         218406          |         74004          |
-| acceptOffer         |           0           |         532153          |         205460         |
-| cancelOffer         |           0           |         416953          |         155886         |
+| registerMarketplace |           0           |         212509          |         81318          |
+| sellNft             |           0           |         331963          |         168010         |
+| auctionNft          |           0           |         332804          |         160593         |
+| makeSimpleOffer     |           0           |         459344          |         281963         |
+| buy                 |           0           |         1299977         |        1137536         |
+| bid                 |           0           |        10363327         |        10185075        |
+| cancelSale          |           0           |         245636          |         99899          |
+| updateFixedPrice    |           0           |         203020          |         73999          |
+| acceptOffer         |           0           |         408949          |         205417         |
+| cancelOffer         |           0           |         332201          |         155857         |

--- a/e2e/test/MarketPlace/TxCosts.md
+++ b/e2e/test/MarketPlace/TxCosts.md
@@ -4,27 +4,27 @@
 |:--------------------|:------------:|:--------------:|:-------------------------:|
 | registerMarketplace |      0       |     28523      |           10843           |
 | sellNft             |      0       |     45619      |           22404           |
-| auctionNft          |      0       |     45698      |           21416           |
-| makeSimpleOffer     |      0       |     49994      |           37599           |
+| auctionNft          |      0       |     45698      |           21415           |
+| makeSimpleOffer     |      0       |     49994      |           37598           |
 | buy                 |      0       |     42799      |          151674           |
-| bid                 |      0       |     50373      |          1358014          |
+| bid                 |      0       |     50373      |          1358013          |
 | cancelSale          |      0       |     33131      |           13321           |
 | updateFixedPrice    |      0       |     27601      |           9867            |
-| acceptOffer         |      0       |     55842      |           27394           |
-| cancelOffer         |      0       |     45669      |           20785           |
+| acceptOffer         |      0       |     55842      |           27393           |
+| cancelOffer         |      0       |     45669      |           20784           |
 
 
 ## Generated tx costs(fees) for Marketplace Precompiles
 
 | Function Call       | Contract cost (Drops) | Precompile cost (Drops) | Extrinsic cost (Drops) |
 |:--------------------|:---------------------:|:-----------------------:|:----------------------:|
-| registerMarketplace |           0           |         213050          |         81325          |
-| sellNft             |           0           |         333944          |         168037         |
-| auctionNft          |           0           |         334836          |         160621         |
-| makeSimpleOffer     |           0           |         461842          |         281998         |
-| buy                 |           0           |         1301702         |        1137561         |
-| bid                 |           0           |        10365893         |        10185111        |
-| cancelSale          |           0           |         246664          |         99913          |
-| updateFixedPrice    |           0           |         203425          |         74004          |
-| acceptOffer         |           0           |         412144          |         205462         |
-| cancelOffer         |           0           |         334406          |         155888         |
+| registerMarketplace |           0           |         213050          |         81324          |
+| sellNft             |           0           |         333944          |         168032         |
+| auctionNft          |           0           |         334836          |         160616         |
+| makeSimpleOffer     |           0           |         461842          |         281992         |
+| buy                 |           0           |         1301702         |        1137556         |
+| bid                 |           0           |        10365893         |        10185104        |
+| cancelSale          |           0           |         246664          |         99910          |
+| updateFixedPrice    |           0           |         203425          |         74003          |
+| acceptOffer         |           0           |         412144          |         205453         |
+| cancelOffer         |           0           |         334406          |         155882         |

--- a/e2e/test/MarketPlace/TxCosts.md
+++ b/e2e/test/MarketPlace/TxCosts.md
@@ -2,29 +2,29 @@
 
 | Function Call       | Contract gas | Precompile gas | (Extrinsic fee/Gas price) |
 |:--------------------|:------------:|:--------------:|:-------------------------:|
-| registerMarketplace |      0       |     28498      |           10842           |
-| sellNft             |      0       |     45446      |           22401           |
-| auctionNft          |      0       |     45520      |           21412           |
-| makeSimpleOffer     |      0       |     49759      |           37595           |
-| buy                 |      0       |     42648      |          151671           |
-| bid                 |      0       |     50132      |          1358010          |
-| cancelSale          |      0       |     33067      |           13319           |
-| updateFixedPrice    |      0       |     27583      |           9866            |
-| acceptOffer         |      0       |     55532      |           27388           |
-| cancelOffer         |      0       |     45476      |           20780           |
+| registerMarketplace |      0       |     28523      |           10843           |
+| sellNft             |      0       |     45619      |           22404           |
+| auctionNft          |      0       |     45698      |           21416           |
+| makeSimpleOffer     |      0       |     49994      |           37599           |
+| buy                 |      0       |     42799      |          151674           |
+| bid                 |      0       |     50373      |          1358014          |
+| cancelSale          |      0       |     33131      |           13321           |
+| updateFixedPrice    |      0       |     27601      |           9867            |
+| acceptOffer         |      0       |     55842      |           27394           |
+| cancelOffer         |      0       |     45669      |           20785           |
 
 
 ## Generated tx costs(fees) for Marketplace Precompiles
 
 | Function Call       | Contract cost (Drops) | Precompile cost (Drops) | Extrinsic cost (Drops) |
 |:--------------------|:---------------------:|:-----------------------:|:----------------------:|
-| registerMarketplace |           0           |         212509          |         81318          |
-| sellNft             |           0           |         331963          |         168010         |
-| auctionNft          |           0           |         332804          |         160593         |
-| makeSimpleOffer     |           0           |         459344          |         281963         |
-| buy                 |           0           |         1299977         |        1137536         |
-| bid                 |           0           |        10363327         |        10185075        |
-| cancelSale          |           0           |         245636          |         99899          |
-| updateFixedPrice    |           0           |         203020          |         73999          |
-| acceptOffer         |           0           |         408949          |         205417         |
-| cancelOffer         |           0           |         332201          |         155857         |
+| registerMarketplace |           0           |         213050          |         81325          |
+| sellNft             |           0           |         333944          |         168037         |
+| auctionNft          |           0           |         334836          |         160621         |
+| makeSimpleOffer     |           0           |         461842          |         281998         |
+| buy                 |           0           |         1301702         |        1137561         |
+| bid                 |           0           |        10365893         |        10185111        |
+| cancelSale          |           0           |         246664          |         99913          |
+| updateFixedPrice    |           0           |         203425          |         74004          |
+| acceptOffer         |           0           |         412144          |         205462         |
+| cancelOffer         |           0           |         334406          |         155888         |

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -1076,7 +1076,7 @@ impl pallet_evm_chain_id::Config for Runtime {
 
 // Start frontier/EVM stuff
 // Number suitable for TRN, based on the gas benchmarks on current standard spec.
-const BLOCK_GAS_LIMIT: u64 = 14_800_000;
+const BLOCK_GAS_LIMIT: u64 = 15_000_000;
 // Default value from Frontier
 const MAX_POV_SIZE: u64 = 5 * 1024 * 1024;
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -1075,41 +1075,6 @@ impl pallet_evm_chain_id::Config for Runtime {
 }
 
 // Start frontier/EVM stuff
-
-/// Current approximation of the gas/s consumption considering
-/// EVM execution over compiled WASM (on 4.4Ghz CPU).
-/// Given the 500ms Weight, from which 75% only are used for transactions,
-// TODO: optimize for the correct value for block gas limit(i.e correct value for 11_250_000 * 2) or
-// WEIGHT_PER_GAS
-/// the total EVM execution gas limit is: GAS_PER_SECOND * 1 * 0.75 ~= 11_250_000 * 2.
-pub const GAS_PER_SECOND: u64 = 30_000_000;
-
-/// Approximate ratio of the amount of Weight per Gas.
-/// u64 works for approximations because Weight is a very small unit compared to gas.
-pub const WEIGHT_PER_GAS: u64 = WEIGHT_REF_TIME_PER_SECOND / GAS_PER_SECOND;
-
-pub struct FutureverseGasWeightMapping;
-
-impl pallet_evm::GasWeightMapping for FutureverseGasWeightMapping {
-	fn gas_to_weight(gas: u64, without_base_weight: bool) -> Weight {
-		let mut weight = gas.saturating_mul(WEIGHT_PER_GAS);
-
-		if without_base_weight {
-			weight = weight.saturating_sub(
-				<Runtime as frame_system::Config>::BlockWeights::get()
-					.get(frame_support::dispatch::DispatchClass::Normal)
-					.base_extrinsic
-					.ref_time(),
-			);
-		}
-
-		Weight::from_all(weight)
-	}
-	fn weight_to_gas(weight: Weight) -> u64 {
-		weight.div(WEIGHT_PER_GAS).ref_time()
-	}
-}
-
 const BLOCK_GAS_LIMIT: u64 = 75_000_000;
 // Default value from Frontier
 const MAX_POV_SIZE: u64 = 5 * 1024 * 1024;

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -1075,7 +1075,7 @@ impl pallet_evm_chain_id::Config for Runtime {
 }
 
 // Start frontier/EVM stuff
-const BLOCK_GAS_LIMIT: u64 = 75_000_000;
+const BLOCK_GAS_LIMIT: u64 = 150_000_000;
 // Default value from Frontier
 const MAX_POV_SIZE: u64 = 5 * 1024 * 1024;
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -1075,7 +1075,8 @@ impl pallet_evm_chain_id::Config for Runtime {
 }
 
 // Start frontier/EVM stuff
-const BLOCK_GAS_LIMIT: u64 = 150_000_000;
+// Number suitable for TRN, based on the gas benchmarks on current standard spec.
+const BLOCK_GAS_LIMIT: u64 = 14_800_000;
 // Default value from Frontier
 const MAX_POV_SIZE: u64 = 5 * 1024 * 1024;
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -2343,5 +2343,6 @@ mod benches {
 		[pallet_doughnut, Doughnut]
 		[pallet_maintenance_mode, MaintenanceMode]
 		[pallet_crowdsale, Crowdsale]
+		[pallet_evm, EVM]
 	);
 }


### PR DESCRIPTION
## Changelog
 - update the codebase to define `BLOCK_GAS_LIMIT` directly instead of `GAS_PER_SECOND`
 - Gas benchmarking on the standard spec for the optimal value for `BLOCK_GAS_LIMIT`
 - Based on the benchmarking [results](https://futureversecom-my.sharepoint.com/:x:/g/personal/suranga_pathmakumara_futureverse_com/EfkiERzz2bhIje31_Wo5qO4BIbIePxUizoFljZ8PVw1jmQ?e=UiSYhF) optimal value of 15,000,000 is chosen for block gas limit as same as the Ethereum target block gas limit.
