### PR TITLE
CLI options for frontier sqlite backend

### DIFF
--- a/client/src/cli_opt.rs
+++ b/client/src/cli_opt.rs
@@ -1,0 +1,41 @@
+// Copyright 2019-2022 PureStake Inc.
+// This file is part of Moonbeam.
+
+// Moonbeam is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Moonbeam is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Moonbeam.  If not, see <http://www.gnu.org/licenses/>.
+
+/// Available frontier backend types.
+#[derive(Debug, Copy, Clone, Default, clap::ValueEnum)]
+pub enum FrontierBackendType {
+	/// Either RocksDb or ParityDb as per inherited from the global backend settings.
+	#[default]
+	KeyValue,
+	/// Sql database with custom log indexing.
+	Sql,
+}
+
+/// Defines the frontier backend configuration.
+pub enum FrontierBackendConfig {
+	KeyValue,
+	Sql { pool_size: u32, num_ops_timeout: u32, thread_count: u32, cache_size: u64 },
+}
+
+impl Default for FrontierBackendConfig {
+	fn default() -> FrontierBackendConfig {
+		FrontierBackendConfig::KeyValue
+	}
+}
+
+pub struct RpcConfig {
+	pub frontier_backend_config: FrontierBackendConfig,
+}

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -21,6 +21,7 @@ mod chain_spec;
 mod service;
 mod benchmarking;
 mod cli;
+mod cli_opt;
 mod command;
 mod consensus_data_providers;
 mod custom_commands;

--- a/client/src/rpc.rs
+++ b/client/src/rpc.rs
@@ -22,6 +22,8 @@
 
 use std::{collections::BTreeMap, sync::Arc};
 
+use fp_rpc::EthereumRuntimeRPCApi;
+
 use jsonrpsee::RpcModule;
 // Substrate
 use sc_client_api::{
@@ -44,7 +46,7 @@ use sp_blockchain::{
 use sp_consensus::SelectChain;
 use sp_consensus_babe::BabeApi;
 use sp_keystore::KeystorePtr;
-use sp_runtime::traits::BlakeTwo256;
+use sp_runtime::traits::Block as BlockT;
 
 // Frontier
 use fc_rpc::{
@@ -136,16 +138,13 @@ pub struct FullDeps<C, P, A: ChainApi, BE, SC> {
 	pub eth_forced_parent_hashes: Option<BTreeMap<H256, H256>>,
 }
 
-pub fn overrides_handle<C, BE>(client: Arc<C>) -> Arc<OverrideHandle<Block>>
+pub fn overrides_handle<B, C, BE>(client: Arc<C>) -> Arc<OverrideHandle<B>>
 where
-	C: ProvideRuntimeApi<Block> + StorageProvider<Block, BE> + AuxStore,
-	C: HeaderBackend<Block> + HeaderMetadata<Block, Error = BlockChainError>,
-	C: Send + Sync + 'static,
-	C::Api: sp_api::ApiExt<Block>
-		+ fp_rpc::EthereumRuntimeRPCApi<Block>
-		+ fp_rpc::ConvertTransactionRuntimeApi<Block>,
-	BE: Backend<Block> + 'static,
-	BE::State: StateBackend<BlakeTwo256>,
+	B: BlockT,
+	C: ProvideRuntimeApi<B>,
+	C::Api: EthereumRuntimeRPCApi<B>,
+	C: HeaderBackend<B> + StorageProvider<B, BE> + 'static,
+	BE: Backend<B> + 'static,
 {
 	// NB: the following is used to redefine storage schema after certain blocks
 	// on live chains


### PR DESCRIPTION

# Context

The following PR introduces option for using SQL (sqlite) backend for frontier.
Inspired from the code in the current frontier master branch: https://github.com/moonbeam-foundation/moonbeam/blob/69458304ddf40713fa3225c7de673c26ebace7af/node/service/src/lib.rs#L246

This change required the introduction of the `RpcConfig` struct in addition to the 5 new CLI args:
- [frontier_backend_type](https://github.com/moonbeam-foundation/moonbeam/blob/2d0f1e0d3b25cd9b3bf8222ab1595b22ee9d1a24/node/cli/src/cli.rs#L180)
- [frontier_sql_backend_pool_size](https://github.com/moonbeam-foundation/moonbeam/blob/2d0f1e0d3b25cd9b3bf8222ab1595b22ee9d1a24/node/cli/src/cli.rs#L184C6-L184C36)
- [frontier_sql_backend_num_ops_timeout](https://github.com/moonbeam-foundation/moonbeam/blob/2d0f1e0d3b25cd9b3bf8222ab1595b22ee9d1a24/node/cli/src/cli.rs#L188C6-L188C42)
- [frontier_sql_backend_thread_count](https://github.com/moonbeam-foundation/moonbeam/blob/2d0f1e0d3b25cd9b3bf8222ab1595b22ee9d1a24/node/cli/src/cli.rs#L192C6-L192C39)
- [frontier_sql_backend_cache_size](https://github.com/moonbeam-foundation/moonbeam/blob/2d0f1e0d3b25cd9b3bf8222ab1595b22ee9d1a24/node/cli/src/cli.rs#L197C6-L197C37)

Note: The additional attributes in the `RpcConfig` struct are not introduced since they require additional CLI args (and code/logic) which are out of scope for this PR.

# Background

Assuming we want to align with what moonbeam has done here.

According to the [releases page](https://github.com/moonbeam-foundation/moonbeam/releases?page=3) - the new `RpcConfig` arg was introduced to the `open_frontier_backend` function between moonbeam releases [Moonbeam v0.32.2](https://github.com/moonbeam-foundation/moonbeam/releases/tag/v0.32.2) and [runtime-2500](https://github.com/moonbeam-foundation/moonbeam/releases/tag/runtime-2500); where moonbeam referenced [substrate v0.9.40](https://github.com/moonbeam-foundation/moonbeam/blob/d3172714146a58998c94a16da7ae269c525cb9da/Cargo.toml#L129C99-L129C107) and [substrate v0.9.43](https://github.com/moonbeam-foundation/moonbeam/blob/2d0f1e0d3b25cd9b3bf8222ab1595b22ee9d1a24/Cargo.toml#L122) respectively.

However, the `RpcConfig` struct was introduced much before this; before being incorporated into the `open_frontier_backend` function.

The `frontier_backend_type` is parsed and the result of this is set to the `frontier_backend_config` variable - within the `RpcConfig` struct - which is then passed to the `open_frontier_backend` function.

## Usage

```sh
cargo run -- --dev --unsafe-rpc-external --rpc-methods=unsafe --rpc-port=9944  --frontier-backend-type sql
```

When running the node, you will see logs like the following:

```log
...
🏷  Node name: resolute-jellyfish-0491    
👤 Role: AUTHORITY    
💾 Database: RocksDb at /var/folders/v3/xzxr10q56v76ys_bj4kj72840000gn/T/substrateXIBJrM/chains/seed_dev/db/full    
[0] 💸 generated 1 npos voters, 1 from validators and 0 nominators    
[0] 💸 generated 1 npos targets
...
```

The frontier sqlite database will be created in the `db` directory; specifically it's a sibling of the RocksDB database directory; a child of the `seed_dev/frontier` directory.
In this case:
`/var/folders/v3/xzxr10q56v76ys_bj4kj72840000gn/T/substrateXIBJrM/chains/seed_dev/frontier/sql`
