### PR TITLE
Update FeeControl values as same as the mainnet

### DIFF
--- a/e2e/test/Dex/TxCosts.md
+++ b/e2e/test/Dex/TxCosts.md
@@ -1,21 +1,22 @@
 ## Generated tx costs(Gas) for Dex Precompiles
 
 | Function Call            | Contract gas | Precompile gas | (Extrinsic fee/Gas price) |
-| :----------------------- | :----------: | :------------: | :-----------------------: |
-| addLiquidity             |    217853    |     122103     |           28027           |
-| removeLiquidity          |    183441    |     86009      |           23350           |
-| swapExactTokensForTokens |    150598    |     70507      |           23345           |
-| swapTokensForExactTokens |    150743    |     71568      |           25012           |
+|:-------------------------|:------------:|:--------------:|:-------------------------:|
+| addLiquidity             |    217853    |     122103     |           52139           |
+| removeLiquidity          |    183441    |     86009      |           34620           |
+| swapExactTokensForTokens |    150598    |     70507      |           26392           |
+| swapTokensForExactTokens |    150743    |     71568      |           27375           |
 | quote                    |    23716     |     22377      |             0             |
 | getAmountOut             |    26047     |     22447      |             0             |
 | getAmountsOut            |    43843     |     42619      |             0             |
 | getAmountsIn             |    44058     |     42611      |             0             |
 
+
 ## Generated tx costs(fees) for ERC20 Precompiles
 
 | Function Call            | Contract cost (Drops) | Precompile cost (Drops) | Extrinsic cost (Drops) |
-| :----------------------- | :-------------------: | :---------------------: | :--------------------: |
-| addLiquidity             |        2968616        |         1807995         |         420415         |
-| removeLiquidity          |        2365301        |         1260861         |         350263         |
-| swapExactTokensForTokens |        2185298        |         985238          |         350186         |
-| swapTokensForExactTokens |        2187623        |         1004110         |         375190         |
+|:-------------------------|:---------------------:|:-----------------------:|:----------------------:|
+| addLiquidity             |        1484456        |         904088          |         391044         |
+| removeLiquidity          |        1182769        |         630493          |         259652         |
+| swapExactTokensForTokens |        1092758        |         492668          |         197943         |
+| swapTokensForExactTokens |        1093921        |         502105          |         205316         |

--- a/e2e/test/ERC1155/TxCosts.md
+++ b/e2e/test/ERC1155/TxCosts.md
@@ -1,26 +1,27 @@
 ## Generated tx costs(Gas) for ERC1155 Precompiles
 
 | Function Call         | Contract gas | Precompile gas | (Extrinsic fee/Gas price) |
-| :-------------------- | :----------: | :------------: | :-----------------------: |
+|:----------------------|:------------:|:--------------:|:-------------------------:|
 | uri                   |    27560     |     22400      |             0             |
 | balanceOf             |    25957     |     22433      |             0             |
 | balanceOfBatch        |    32585     |     24106      |             0             |
 | setApprovalForAll     |    47025     |     27501      |             0             |
 | isApprovedForAll      |    26076     |     23184      |             0             |
-| safeTransferFrom      |    59163     |     32160      |           23335           |
-| safeBatchTransferFrom |    50205     |     35812      |           26670           |
-| mint                  |    33152     |     32245      |           23503           |
-| mintBatch             |    42210     |     32633      |           26836           |
-| burn                  |    32581     |     27608      |           20002           |
-| burnBatch             |    38043     |     31828      |           23335           |
+| safeTransferFrom      |    59163     |     32160      |           10552           |
+| safeBatchTransferFrom |    50205     |     35812      |           13298           |
+| mint                  |    33152     |     32245      |           11374           |
+| mintBatch             |    42210     |     32633      |           12307           |
+| burn                  |    32581     |     27608      |           9631            |
+| burnBatch             |    38043     |     31828      |           10564           |
+
 
 ## Generated tx costs(fees) for ERC1155 Precompiles
 
 | Function Call         | Contract cost (Drops) | Precompile cost (Drops) | Extrinsic cost (Drops) |
-| :-------------------- | :-------------------: | :---------------------: | :--------------------: |
-| safeTransferFrom      |        880468         |         462181          |         350038         |
-| safeBatchTransferFrom |        728112         |         535973          |         400055         |
-| mint                  |        493954         |         464911          |         352545         |
-| mintBatch             |        589858         |         477332          |         402545         |
-| burn                  |        475652         |         407185          |         300038         |
-| burnBatch             |        569231         |         451575          |         350038         |
+|:----------------------|:---------------------:|:-----------------------:|:----------------------:|
+| safeTransferFrom      |        440278         |         231113          |         79145          |
+| safeBatchTransferFrom |        364092         |         268013          |         99741          |
+| mint                  |        247001         |         232478          |         85307          |
+| mintBatch             |        294958         |         238690          |         92307          |
+| burn                  |        237850         |         203613          |         72233          |
+| burnBatch             |        284644         |         225810          |         79233          |

--- a/e2e/test/ERC20/TxCosts.md
+++ b/e2e/test/ERC20/TxCosts.md
@@ -1,21 +1,22 @@
 ## Generated tx costs(Gas) for ERC20 Precompiles
 
 | Function Call | Contract gas | Precompile gas | (Extrinsic fee/Gas price) |
-| :------------ | :----------: | :------------: | :-----------------------: |
+|:--------------|:------------:|:--------------:|:-------------------------:|
 | totalSupply   |    23717     |     22388      |             0             |
 | balanceOf     |    25860     |     23974      |             0             |
 | allowance     |    26064     |     23273      |             0             |
-| approval      |    47152     |     26470      |           20170           |
-| transfer      |    52698     |     43641      |           20172           |
-| transferFrom  |    44716     |     51726      |           23340           |
+| approval      |    47152     |     26470      |           11782           |
+| transfer      |    52698     |     43641      |           15507           |
+| transferFrom  |    44716     |     51726      |           18731           |
 | name          |    25926     |     22388      |             0             |
 | decimals      |    22354     |     22388      |             0             |
 | symbol        |    25945     |     22388      |             0             |
 
+
 ## Generated tx costs(fees) for ERC20 Precompiles
 
 | Function Call | Contract cost (Drops) | Precompile cost (Drops) | Extrinsic cost (Drops) |
-| :------------ | :-------------------: | :---------------------: | :--------------------: |
-| approval      |        702835         |         396804          |         302557         |
-| transfer      |        781323         |         622692          |         302592         |
-| transferFrom  |        647164         |         760526          |         350114         |
+|:--------------|:---------------------:|:-----------------------:|:----------------------:|
+| approval      |        351452         |         198422          |         88369          |
+| transfer      |        390700         |         311427          |         116305         |
+| transferFrom  |        323614         |         380276          |         140487         |

--- a/e2e/test/ERC721/TxCosts.md
+++ b/e2e/test/ERC721/TxCosts.md
@@ -1,32 +1,33 @@
 ## Generated tx costs(Gas) for ERC721 Precompiles
 
 | Function Call     | Contract gas | Precompile gas | (Extrinsic fee/Gas price) |
-| :---------------- | :----------: | :------------: | :-----------------------: |
+|:------------------|:------------:|:--------------:|:-------------------------:|
 | balanceOf         |    25895     |     23274      |             0             |
 | ownerOf           |    25847     |     23242      |             0             |
 | getApproved       |    27395     |     23242      |             0             |
 | isApprovedForAll  |    26082     |     23973      |             0             |
-| mint              |    53193     |     31731      |           17336           |
-| burn              |    37870     |     35731      |           17170           |
-| approve           |    50740     |     28884      |           23835           |
-| setApprovalForAll |    47011     |     26467      |           23335           |
+| mint              |    53193     |     31731      |           9216            |
+| burn              |    37870     |     35731      |           10523           |
+| approve           |    50740     |     28884      |           10852           |
+| setApprovalForAll |    47011     |     26467      |           9700            |
 | safetransferFrom  |    67181     |     36625      |             0             |
-| transferFrom      |    66839     |     35560      |           20670           |
+| transferFrom      |    66839     |     35560      |           11585           |
 | name              |    25932     |     22388      |             0             |
 | symbol            |    25938     |     22388      |             0             |
 | tokenURI          |    25964     |     23242      |             0             |
 | owner             |    23728     |     22388      |             0             |
-| transferOwnership |    29147     |     28498      |           19835           |
-| renounceOwnership |    30272     |     28372      |           19835           |
+| transferOwnership |    29147     |     28498      |           9501            |
+| renounceOwnership |    30272     |     28372      |           9455            |
+
 
 ## Generated tx costs(fees) for ERC721 Precompiles
 
 | Function Call     | Contract cost (Drops) | Precompile cost (Drops) | Extrinsic cost (Drops) |
-| :---------------- | :-------------------: | :---------------------: | :--------------------: |
-| mint              |        791884         |         448454          |         260041         |
-| burn              |        490684         |         533648          |         257553         |
-| approve           |        739543         |         430633          |         357539         |
-| setApprovalForAll |        699609         |         396639          |         350030         |
-| transferFrom      |        884488         |         528637          |         310054         |
-| transferOwnership |        436153         |         424962          |         297536         |
-| renounceOwnership |        352310         |         419621          |         297536         |
+|:------------------|:---------------------:|:-----------------------:|:----------------------:|
+| mint              |        395981         |         224249          |         69126          |
+| burn              |        245366         |         266850          |         78929          |
+| approve           |        369808         |         215338          |         81394          |
+| setApprovalForAll |        349839         |         198339          |         72754          |
+| transferFrom      |        442288         |         264345          |         86893          |
+| transferOwnership |        218098         |         212502          |         71263          |
+| renounceOwnership |        176172         |         209831          |         70913          |

--- a/e2e/test/Futurepass/TxCosts.md
+++ b/e2e/test/Futurepass/TxCosts.md
@@ -1,19 +1,20 @@
 ## Generated tx costs(Gas) for Futurepass Precompiles
 
 | Function Call                 | Contract gas | Precompile gas | (Extrinsic fee/Gas price) |
-| :---------------------------- | :----------: | :------------: | :-----------------------: |
-| create                        |      0       |     45155      |           19173           |
-| registerDelegateWithSignature |      0       |     46072      |           34006           |
-| unregisterDelegate            |      0       |     43622      |           22339           |
-| transferOwnership             |      0       |     52086      |           22508           |
-| proxyCall                     |      0       |     65694      |           24009           |
+|:------------------------------|:------------:|:--------------:|:-------------------------:|
+| create                        |      0       |     45155      |           16355           |
+| registerDelegateWithSignature |      0       |     46056      |           20190           |
+| unregisterDelegate            |      0       |     43622      |           16203           |
+| transferOwnership             |      0       |     52086      |           20410           |
+| proxyCall                     |      0       |     65694      |           21155           |
+
 
 ## Generated tx costs(fees) for Futurepass Precompiles
 
 | Function Call                 | Contract cost (Drops) | Precompile cost (Drops) | Extrinsic cost (Drops) |
-| :---------------------------- | :-------------------: | :---------------------: | :--------------------: |
-| create                        |           0           |         657200          |         287602         |
-| registerDelegateWithSignature |           0           |         678157          |         510100         |
-| unregisterDelegate            |           0           |         622142          |         335093         |
-| transferOwnership             |           0           |         768256          |         337632         |
-| proxyCall                     |           0           |         899654          |         360135         |
+|:------------------------------|:---------------------:|:-----------------------:|:----------------------:|
+| create                        |           0           |         328633          |         122663         |
+| registerDelegateWithSignature |           0           |         338932          |         151432         |
+| unregisterDelegate            |           0           |         311102          |         121523         |
+| transferOwnership             |           0           |         384166          |         153079         |
+| proxyCall                     |           0           |         449872          |         158668         |

--- a/e2e/test/MarketPlace/TxCosts.md
+++ b/e2e/test/MarketPlace/TxCosts.md
@@ -1,29 +1,30 @@
 ## Generated tx costs(Gas) for Marketplace Precompiles
 
 | Function Call       | Contract gas | Precompile gas | (Extrinsic fee/Gas price) |
-| :------------------ | :----------: | :------------: | :-----------------------: |
-| registerMarketplace |      0       |     32307      |           20003           |
-| sellNft             |      0       |     55445      |           27175           |
-| auctionNft          |      0       |     55709      |           23675           |
-| makeSimpleOffer     |      0       |     60972      |           28011           |
-| buy                 |      0       |     50424      |           85174           |
-| bid                 |      0       |     61632      |          687845           |
-| cancelSale          |      0       |     38090      |           18505           |
-| updateFixedPrice    |      0       |     29163      |           21169           |
-| acceptOffer         |      0       |     74959      |           17174           |
-| cancelOffer         |      0       |     56308      |           17169           |
+|:--------------------|:------------:|:--------------:|:-------------------------:|
+| registerMarketplace |      0       |     32307      |           10843           |
+| sellNft             |      0       |     55445      |           22404           |
+| auctionNft          |      0       |     55709      |           21416           |
+| makeSimpleOffer     |      0       |     60972      |           37599           |
+| buy                 |      0       |     50424      |          151674           |
+| bid                 |      0       |     61632      |          1358014          |
+| cancelSale          |      0       |     38090      |           13321           |
+| updateFixedPrice    |      0       |     29163      |           9867            |
+| acceptOffer         |      0       |     74959      |           27394           |
+| cancelOffer         |      0       |     56308      |           20784           |
+
 
 ## Generated tx costs(fees) for Marketplace Precompiles
 
 | Function Call       | Contract cost (Drops) | Precompile cost (Drops) | Extrinsic cost (Drops) |
-| :------------------ | :-------------------: | :---------------------: | :--------------------: |
-| registerMarketplace |           0           |         466921          |         300049         |
-| sellNft             |           0           |         816231          |         407639         |
-| auctionNft          |           0           |         821662          |         355139         |
-| makeSimpleOffer     |           0           |         1010831         |         420171         |
-| buy                 |           0           |         1732808         |        1277623         |
-| bid                 |           0           |        10924137         |        10317675        |
-| cancelSale          |           0           |         570522          |         277576         |
-| updateFixedPrice    |           0           |         436768          |         317537         |
-| acceptOffer         |           0           |         1064301         |         257612         |
-| cancelOffer         |           0           |         833923          |         257549         |
+|:--------------------|:---------------------:|:-----------------------:|:----------------------:|
+| registerMarketplace |           0           |         233484          |         81325          |
+| sellNft             |           0           |         408156          |         168036         |
+| auctionNft          |           0           |         410872          |         160620         |
+| makeSimpleOffer     |           0           |         555461          |         281997         |
+| buy                 |           0           |         1366440         |        1137559         |
+| bid                 |           0           |        10462114         |        10185109        |
+| cancelSale          |           0           |         285289          |         99912          |
+| updateFixedPrice    |           0           |         218406          |         74004          |
+| acceptOffer         |           0           |         532153          |         205460         |
+| cancelOffer         |           0           |         416953          |         155886         |

--- a/pallet/common/src/lib.rs
+++ b/pallet/common/src/lib.rs
@@ -371,15 +371,16 @@ pub trait FeeConfig {
 impl FeeConfig for () {
 	fn evm_base_fee_per_gas() -> U256 {
 		// Floor network base fee per gas
-		// 0.000015 XRP per gas, 15000 GWEI
-		U256::from(15_000_000_000_000u128)
+		// set the same values as the mainnet. 7,500 GWEI.
+		// This will result a transfer tx costs 0.0000075*21000 = 0.1575 XRP
+		U256::from(7_500_000_000_000u128)
 	}
 	fn weight_multiplier() -> Perbill {
-		Perbill::from_parts(125)
-	}
+		Perbill::from_parts(100_000)
+	} // 0.01%
 
 	fn length_multiplier() -> Balance {
-		Balance::from(2_500u32)
+		Balance::from(350u32)
 	}
 }
 


### PR DESCRIPTION
### Changelog
 - Updates default `FeeControl::FeeConfig` values as same as the mainnet values -> https://portal.rootnet.live/?rpc=wss%3A%2F%2Froot.rootnet.live%2Farchive%2Fws#/chainstate
 - Generate cost figures based on new control values.
