### PR TITLE
Release 8.55.0

### DIFF
--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -158,10 +158,10 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("root"),
 	impl_name: create_runtime_str!("root"),
 	authoring_version: 1,
-	spec_version: 54,
+	spec_version: 55,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
-	transaction_version: 9,
+	transaction_version: 10,
 	state_version: 0,
 };
 


### PR DESCRIPTION
# Release

**Release Name:** `8.55.0`

**Spec Version:** `55`

**Client Version:** `8.0.0`

## Key Changes:

This release introduces the following changes:
- Upgrade Substrate to `v1.0.0` 
- Update `MAXIMUM_BLOCK_WEIGHT` to 1s
- Update `BLOCK_GAS_LIMIT` to 15 Million

## PRs included:
- https://github.com/futureversecom/trn-seed/pull/821

---

## Client Changes:
- [x] Yes
- [ ] No

## Runtime Changes:
- [x] Yes
- [ ] No

### Storage Changes:

### Extrinsic Changes:

### Event Changes:

### Storage Migrations:
 - https://github.com/futureversecom/trn-seed/pull/821#:~:text=Important%20Migrations