### PR TITLE
Release 8.56.0

### DIFF
--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -158,7 +158,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("root"),
 	impl_name: create_runtime_str!("root"),
 	authoring_version: 1,
-	spec_version: 55,
+	spec_version: 56,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 10,


### PR DESCRIPTION
# Release

**Release Name:** `8.56.0`

**Spec Version:** `56`

**Client Version:** `8.0.0`

## Key Changes:

This release introduces the following changes:
- Upgrade Substrate to v1.0.0
- Update MAXIMUM_BLOCK_WEIGHT to 1s
- Update BLOCK_GAS_LIMIT to 15 Million
- Update the build toolchain to `stable 1.80.0` 

## PRs included:
- https://github.com/futureversecom/trn-seed/pull/821
- https://github.com/futureversecom/trn-seed/pull/869

---

## Client Changes:
- [x] Yes
- [ ] No
NOTE - recommend upgrading to the latest image `8.56.0`

## Runtime Changes:
- [x] Yes
- [ ] No

### Storage Changes:

### Extrinsic Changes:

### Event Changes:

### Storage Migrations:
 - https://github.com/futureversecom/trn-seed/pull/821#:~:text=Important%20Migrations