### PR TITLE
TRN-530 check token owner on simple offer

### DIFF
--- a/pallet/marketplace/src/impls.rs
+++ b/pallet/marketplace/src/impls.rs
@@ -312,7 +312,7 @@ impl<T: Config> Pallet<T> {
 	) -> Result<OfferId, DispatchError> {
 		ensure!(!amount.is_zero(), Error::<T>::ZeroOffer);
 		let token_owner = T::NFTExt::get_token_owner(&token_id);
-		ensure!(!token_owner.is_none(), Error::<T>::NoTokenOwner);
+		ensure!(token_owner.is_some(), Error::<T>::NoToken);
 		ensure!(token_owner != Some(who), Error::<T>::IsTokenOwner);
 		let offer_id = Self::next_offer_id();
 		ensure!(offer_id.checked_add(One::one()).is_some(), Error::<T>::NoAvailableIds);

--- a/pallet/marketplace/src/impls.rs
+++ b/pallet/marketplace/src/impls.rs
@@ -311,7 +311,9 @@ impl<T: Config> Pallet<T> {
 		marketplace_id: Option<MarketplaceId>,
 	) -> Result<OfferId, DispatchError> {
 		ensure!(!amount.is_zero(), Error::<T>::ZeroOffer);
-		ensure!(T::NFTExt::get_token_owner(&token_id) != Some(who), Error::<T>::IsTokenOwner);
+		let token_owner = T::NFTExt::get_token_owner(&token_id);
+		ensure!(!token_owner.is_none(), Error::<T>::NoTokenOwner);
+		ensure!(token_owner != Some(who), Error::<T>::IsTokenOwner);
 		let offer_id = Self::next_offer_id();
 		ensure!(offer_id.checked_add(One::one()).is_some(), Error::<T>::NoAvailableIds);
 

--- a/pallet/marketplace/src/lib.rs
+++ b/pallet/marketplace/src/lib.rs
@@ -325,8 +325,8 @@ pub mod pallet {
 		TokenOnAuction,
 		/// No tokens were specified in the listing
 		EmptyTokens,
-		/// Token does not have an owner, likely the token has been burnt
-		NoTokenOwner,
+		/// The token does not exist
+		NoToken,
 	}
 
 	#[pallet::hooks]

--- a/pallet/marketplace/src/lib.rs
+++ b/pallet/marketplace/src/lib.rs
@@ -325,6 +325,8 @@ pub mod pallet {
 		TokenOnAuction,
 		/// No tokens were specified in the listing
 		EmptyTokens,
+		/// Token does not have an owner, likely the token has been burnt
+		NoTokenOwner,
 	}
 
 	#[pallet::hooks]

--- a/pallet/marketplace/src/tests.rs
+++ b/pallet/marketplace/src/tests.rs
@@ -2172,6 +2172,31 @@ fn make_simple_offer() {
 }
 
 #[test]
+fn make_simple_offer_on_burnt_token_should_fail() {
+	let buyer = create_account(7);
+
+	TestExt::<Test>::default().build().execute_with(|| {
+		let (collection_id, token_id, token_owner) = setup_nft_token();
+		assert_eq!(
+			Nft::owned_tokens(collection_id, &token_owner, 0, 1000),
+			(token_id.1, 1, vec![token_id.1])
+		);
+		assert_ok!(Nft::burn(Some(token_owner).into(), token_id));
+		let offer_amount: Balance = 100;
+		assert_noop!(
+			Marketplace::make_simple_offer(
+				Some(buyer).into(),
+				token_id,
+				offer_amount,
+				NativeAssetId::get(),
+				None
+			),
+			Error::<Test>::NoTokenOwner
+		);
+	});
+}
+
+#[test]
 fn make_simple_offer_insufficient_funds_should_fail() {
 	TestExt::<Test>::default().build().execute_with(|| {
 		let (_, token_id, _) = setup_nft_token();

--- a/pallet/marketplace/src/tests.rs
+++ b/pallet/marketplace/src/tests.rs
@@ -2191,7 +2191,27 @@ fn make_simple_offer_on_burnt_token_should_fail() {
 				NativeAssetId::get(),
 				None
 			),
-			Error::<Test>::NoTokenOwner
+			Error::<Test>::NoToken
+		);
+	});
+}
+
+#[test]
+fn make_simple_offer_on_non_existent_token_should_fail() {
+	let buyer = create_account(7);
+
+	TestExt::<Test>::default().build().execute_with(|| {
+		let (collection_id, _, _) = setup_nft_token();
+		let offer_amount: Balance = 100;
+		assert_noop!(
+			Marketplace::make_simple_offer(
+				Some(buyer).into(),
+				(collection_id, 456), // non existent token
+				offer_amount,
+				NativeAssetId::get(),
+				None
+			),
+			Error::<Test>::NoToken
 		);
 	});
 }


### PR DESCRIPTION
This PR address an issue with the simple offer extrinsic in the marketplace pallet. The issue is that the extrinsic allows for simple offers to be made on tokens that have been burnt. 

To fix this an additional check has been added to the pallet that checks the owner of the token of interest before processing. Returning an error NoTokenOwner in the failure case where the owner is None.

[Related issue](https://futureverse.atlassian.net/jira/software/c/projects/TRN/boards/158?assignee=712020:e6af0fd1-96ad-49ff-8750-5ff03ad831e8&selectedIssue=TRN-530)

**PR checklist**  

- [X] Describe the added/changed/fixed/removed behaviour
- [X] Tag related issue(s)
- [ ] Add appropriate unit tests and/or integration tests to the [integration test repository](https://github.com/futureversecom/seed-integration-tests)
