### PR TITLE
TRN-400 Emit event when listing is closed from accepted offer

### DIFF
--- a/pallet/marketplace/src/impls.rs
+++ b/pallet/marketplace/src/impls.rs
@@ -385,7 +385,7 @@ impl<T: Config> Pallet<T> {
 							tokens: sale.tokens,
 							listing_id,
 							marketplace_id: sale.marketplace_id,
-							reason: FixedPriceClosureReason::VendorCancelled,
+							reason: FixedPriceClosureReason::OfferAccepted,
 						});
 					},
 					// Offer cannot be made on auctions

--- a/pallet/marketplace/src/impls.rs
+++ b/pallet/marketplace/src/impls.rs
@@ -379,6 +379,19 @@ impl<T: Config> Pallet<T> {
 		if let Some(TokenLockReason::Listed(listing_id)) = T::NFTExt::get_token_lock(offer.token_id)
 		{
 			if let Some(listing) = <Listings<T>>::get(listing_id) {
+				match listing.clone() {
+					Listing::<T>::FixedPrice(sale) => {
+						Self::deposit_event(Event::<T>::FixedPriceSaleClose {
+							tokens: sale.tokens,
+							listing_id,
+							marketplace_id: sale.marketplace_id,
+							reason: FixedPriceClosureReason::VendorCancelled,
+						});
+					},
+					// Offer cannot be made on auctions
+					_ => {},
+				}
+
 				Self::remove_listing(listing, listing_id);
 			}
 		}

--- a/pallet/marketplace/src/tests.rs
+++ b/pallet/marketplace/src/tests.rs
@@ -2344,7 +2344,7 @@ fn make_simple_offer_on_fixed_price_listing() {
 				tokens: ListingTokens::Nft(NftListing { collection_id, serial_numbers }),
 				listing_id,
 				marketplace_id: None,
-				reason: FixedPriceClosureReason::VendorCancelled,
+				reason: FixedPriceClosureReason::OfferAccepted,
 			}));
 		});
 }

--- a/pallet/marketplace/src/tests.rs
+++ b/pallet/marketplace/src/tests.rs
@@ -2296,7 +2296,7 @@ fn make_simple_offer_on_fixed_price_listing() {
 			assert_ok!(Marketplace::sell_nft(
 				Some(token_owner).into(),
 				collection_id,
-				serial_numbers,
+				serial_numbers.clone(),
 				None,
 				NativeAssetId::get(),
 				sell_price,
@@ -2339,6 +2339,13 @@ fn make_simple_offer_on_fixed_price_listing() {
 			)
 			.is_zero());
 			assert_eq!(AssetsExt::balance(NativeAssetId::get(), &token_owner), offer_amount);
+
+			System::assert_has_event(MockEvent::Marketplace(Event::<Test>::FixedPriceSaleClose {
+				tokens: ListingTokens::Nft(NftListing { collection_id, serial_numbers }),
+				listing_id,
+				marketplace_id: None,
+				reason: FixedPriceClosureReason::VendorCancelled,
+			}));
 		});
 }
 

--- a/pallet/marketplace/src/types.rs
+++ b/pallet/marketplace/src/types.rs
@@ -213,6 +213,8 @@ pub enum FixedPriceClosureReason {
 	VendorCancelled,
 	/// Listing expired
 	Expired,
+	/// Vendor accepted a buy offer
+	OfferAccepted,
 }
 
 /// Information about a marketplace


### PR DESCRIPTION
This PR modifies the `accept_offer` impl in the marketplace pallet so that it emits a `FixedPriceSaleClose` event in the case an offer is accepted, whilst a listing for that token already exists.

This allows front-end experiences to track this particular event when it occurs.