### PR TITLE
Remove mapping from xrpl asset map

### DIFF
--- a/pallet/xrpl-bridge/src/benchmarking.rs
+++ b/pallet/xrpl-bridge/src/benchmarking.rs
@@ -289,23 +289,6 @@ benchmarks! {
 		assert_eq!(AssetIdToXRPL::<T>::get(asset_id), Some(xrpl_currency));
 		assert_eq!(XRPLToAssetId::<T>::get(xrpl_currency), Some(asset_id));
 	}
-
-	remove_xrpl_asset_map {
-		let alice = account::<T>("Alice");
-		let destination: XrplAccountId = [0u8; 20].into();
-		let asset_id = T::NativeAssetId::get();
-		let tx_fee = DoorTxFee::<T>::get();
-		let xrpl_symbol =
-			XRPLCurrencyType::NonStandard(hex!("524F4F5400000000000000000000000000000000").into());
-		let xrpl_currency = XRPLCurrency { symbol: xrpl_symbol.clone(), issuer: destination };
-		<AssetIdToXRPL<T>>::insert(asset_id, Some(xrpl_currency));
-		<XRPLToAssetId<T>>::insert(xrpl_currency, Some(asset_id));
-	}: _(RawOrigin::Root, asset_id, xrpl_currency)
-	verify {
-		assert_eq!(AssetIdToXRPL::<T>::get(asset_id), None);
-		assert_eq!(XRPLToAssetId::<T>::get(xrpl_currency), None);
-	}
-
 }
 
 impl_benchmark_test_suite!(

--- a/pallet/xrpl-bridge/src/benchmarking.rs
+++ b/pallet/xrpl-bridge/src/benchmarking.rs
@@ -290,6 +290,22 @@ benchmarks! {
 		assert_eq!(XRPLToAssetId::<T>::get(xrpl_currency), Some(asset_id));
 	}
 
+	remove_xrpl_asset_map {
+		let alice = account::<T>("Alice");
+		let destination: XrplAccountId = [0u8; 20].into();
+		let asset_id = T::NativeAssetId::get();
+		let tx_fee = DoorTxFee::<T>::get();
+		let xrpl_symbol =
+			XRPLCurrencyType::NonStandard(hex!("524F4F5400000000000000000000000000000000").into());
+		let xrpl_currency = XRPLCurrency { symbol: xrpl_symbol.clone(), issuer: destination };
+		<AssetIdToXRPL<T>>::insert(asset_id, Some(xrpl_currency));
+		<XRPLToAssetId<T>>::insert(xrpl_currency, Some(asset_id));
+	}: _(RawOrigin::Root, asset_id, xrpl_currency)
+	verify {
+		assert_eq!(AssetIdToXRPL::<T>::get(asset_id), None);
+		assert_eq!(XRPLToAssetId::<T>::get(xrpl_currency), None);
+	}
+
 }
 
 impl_benchmark_test_suite!(

--- a/pallet/xrpl-bridge/src/benchmarking.rs
+++ b/pallet/xrpl-bridge/src/benchmarking.rs
@@ -284,7 +284,7 @@ benchmarks! {
 		let xrpl_symbol =
 			XRPLCurrencyType::NonStandard(hex!("524F4F5400000000000000000000000000000000").into());
 		let xrpl_currency = XRPLCurrency { symbol: xrpl_symbol.clone(), issuer: destination };
-	}: _(RawOrigin::Root, asset_id, xrpl_currency)
+	}: _(RawOrigin::Root, asset_id, Some(xrpl_currency))
 	verify {
 		assert_eq!(AssetIdToXRPL::<T>::get(asset_id), Some(xrpl_currency));
 		assert_eq!(XRPLToAssetId::<T>::get(xrpl_currency), Some(asset_id));

--- a/pallet/xrpl-bridge/src/benchmarking.rs
+++ b/pallet/xrpl-bridge/src/benchmarking.rs
@@ -107,7 +107,7 @@ benchmarks! {
 		assert_ok!(XrplBridge::<T>::set_xrpl_asset_map(
 			RawOrigin::Root.into(),
 			asset_id,
-			xrpl_currency
+			Some(xrpl_currency)
 		));
 		assert_ok!(XrplBridge::<T>::set_door_address(RawOrigin::Root.into(), door_address));
 		// Mint ROOT tokens to withdraw

--- a/pallet/xrpl-bridge/src/lib.rs
+++ b/pallet/xrpl-bridge/src/lib.rs
@@ -17,7 +17,8 @@
 
 use crate::types::{
 	AssetWithdrawTransaction, DelayedPaymentId, DelayedWithdrawal, WithdrawTransaction,
-	XRPLCurrency, XrpTransaction, XrpWithdrawTransaction, XrplTicketSequenceParams, XrplTxData,
+	XRPLCurrency, XRPLCurrencyType, XrpTransaction, XrpWithdrawTransaction,
+	XrplTicketSequenceParams, XrplTxData,
 };
 use frame_support::{
 	fail,

--- a/pallet/xrpl-bridge/src/lib.rs
+++ b/pallet/xrpl-bridge/src/lib.rs
@@ -248,6 +248,10 @@ pub mod pallet {
 			asset_id: AssetId,
 			xrpl_currency: XRPLCurrency,
 		},
+		XrplAssetMapRemoved {
+			asset_id: AssetId,
+			xrpl_currency: XRPLCurrency,
+		},
 	}
 
 	#[pallet::hooks]
@@ -772,6 +776,23 @@ pub mod pallet {
 			<AssetIdToXRPL<T>>::insert(asset_id, xrpl_currency);
 			<XRPLToAssetId<T>>::insert(xrpl_currency, asset_id);
 			Self::deposit_event(Event::XrplAssetMapSet { asset_id, xrpl_currency });
+			Ok(())
+		}
+
+		#[pallet::call_index(15)]
+		#[pallet::weight(T::WeightInfo::remove_xrpl_asset_map())]
+		/// Remove the mapping for an asset to an xrpl symbol (requires governance)
+		/// Removes both XRPLToAssetId and AssetIdToXRPL
+		pub fn remove_xrpl_asset_map(origin: OriginFor<T>, asset_id: AssetId) -> DispatchResult {
+			ensure_root(origin)?;
+			let xrpl_currency =
+				AssetIdToXRPL::<T>::get(asset_id).ok_or(Error::<T>::AssetNotSupported)?;
+			<AssetIdToXRPL<T>>::remove(asset_id.clone());
+			<XRPLToAssetId<T>>::remove(xrpl_currency);
+			Self::deposit_event(Event::XrplAssetMapRemoved {
+				asset_id: asset_id.clone(),
+				xrpl_currency,
+			});
 			Ok(())
 		}
 	}

--- a/pallet/xrpl-bridge/src/tests.rs
+++ b/pallet/xrpl-bridge/src/tests.rs
@@ -1563,6 +1563,54 @@ fn set_xrpl_asset_map_works() {
 }
 
 #[test]
+fn remove_xrpl_asset_map_works() {
+	TestExt::<Test>::default().build().execute_with(|| {
+		let asset_id = 1;
+		let issuer = XrplAccountId::from_slice(b"6490B68F1116BFE87DDD");
+		let xrpl_symbol =
+			XRPLCurrencyType::NonStandard(hex!("524F4F5400000000000000000000000000000000").into());
+		let xrpl_currency = XRPLCurrency { symbol: xrpl_symbol, issuer };
+		assert_ok!(XRPLBridge::set_xrpl_asset_map(RuntimeOrigin::root(), asset_id, xrpl_currency));
+		assert_eq!(AssetIdToXRPL::<Test>::get(asset_id), Some(xrpl_currency));
+		assert_eq!(XRPLToAssetId::<Test>::get(xrpl_currency), Some(asset_id));
+		assert_ok!(XRPLBridge::remove_xrpl_asset_map(RuntimeOrigin::root(), asset_id));
+		System::assert_has_event(
+			Event::<Test>::XrplAssetMapRemoved { asset_id, xrpl_currency }.into(),
+		);
+	})
+}
+
+#[test]
+fn remove_xrpl_asset_map_not_sudo_fails() {
+	TestExt::<Test>::default().build().execute_with(|| {
+		let asset_id = 1;
+		let account: AccountId = [1_u8; 20].into();
+		let issuer = XrplAccountId::from_slice(b"6490B68F1116BFE87DDD");
+		let xrpl_symbol =
+			XRPLCurrencyType::NonStandard(hex!("524F4F5400000000000000000000000000000000").into());
+		let xrpl_currency = XRPLCurrency { symbol: xrpl_symbol, issuer };
+		assert_noop!(
+			XRPLBridge::remove_xrpl_asset_map(
+				RuntimeOrigin::signed(account),
+				asset_id,
+				xrpl_currency
+			),
+			BadOrigin
+		);
+	})
+}
+
+#[test]
+fn remove_xrpl_asset_map_fails_with_no_mapping() {
+	TestExt::<Test>::default().build().execute_with(|| {
+		assert_noop!(
+			XRPLBridge::remove_xrpl_asset_map(RuntimeOrigin::root(), asset_id, xrpl_currency),
+			Error::<Test>::AssetNotSupported
+		);
+	})
+}
+
+#[test]
 fn set_xrpl_asset_map_invalid_currency_code() {
 	TestExt::<Test>::default().build().execute_with(|| {
 		let asset_id = 1;

--- a/pallet/xrpl-bridge/src/tests.rs
+++ b/pallet/xrpl-bridge/src/tests.rs
@@ -1592,6 +1592,7 @@ fn remove_xrpl_asset_map_works() {
 #[test]
 fn remove_xrpl_asset_map_fails_with_no_mapping() {
 	TestExt::<Test>::default().build().execute_with(|| {
+		let asset_id = 1;
 		let xrpl_currency = None;
 		assert_noop!(
 			XRPLBridge::set_xrpl_asset_map(RuntimeOrigin::root(), asset_id, xrpl_currency),

--- a/pallet/xrpl-bridge/src/tests.rs
+++ b/pallet/xrpl-bridge/src/tests.rs
@@ -1573,7 +1573,8 @@ fn remove_xrpl_asset_map_works() {
 		assert_ok!(XRPLBridge::set_xrpl_asset_map(RuntimeOrigin::root(), asset_id, xrpl_currency));
 		assert_eq!(AssetIdToXRPL::<Test>::get(asset_id), Some(xrpl_currency));
 		assert_eq!(XRPLToAssetId::<Test>::get(xrpl_currency), Some(asset_id));
-		assert_ok!(XRPLBridge::remove_xrpl_asset_map(RuntimeOrigin::root(), asset_id));
+		// remove it by sending second param to none
+		assert_ok!(XRPLBridge::set_xrpl_asset_map(RuntimeOrigin::root(), asset_id, None));
 		System::assert_has_event(
 			Event::<Test>::XrplAssetMapRemoved { asset_id, xrpl_currency }.into(),
 		);
@@ -1581,30 +1582,11 @@ fn remove_xrpl_asset_map_works() {
 }
 
 #[test]
-fn remove_xrpl_asset_map_not_sudo_fails() {
-	TestExt::<Test>::default().build().execute_with(|| {
-		let asset_id = 1;
-		let account: AccountId = [1_u8; 20].into();
-		let issuer = XrplAccountId::from_slice(b"6490B68F1116BFE87DDD");
-		let xrpl_symbol =
-			XRPLCurrencyType::NonStandard(hex!("524F4F5400000000000000000000000000000000").into());
-		let xrpl_currency = XRPLCurrency { symbol: xrpl_symbol, issuer };
-		assert_noop!(
-			XRPLBridge::remove_xrpl_asset_map(
-				RuntimeOrigin::signed(account),
-				asset_id,
-				xrpl_currency
-			),
-			BadOrigin
-		);
-	})
-}
-
-#[test]
 fn remove_xrpl_asset_map_fails_with_no_mapping() {
 	TestExt::<Test>::default().build().execute_with(|| {
+		let xrpl_currency = None;
 		assert_noop!(
-			XRPLBridge::remove_xrpl_asset_map(RuntimeOrigin::root(), asset_id, xrpl_currency),
+			XRPLBridge::set_xrpl_asset_map(RuntimeOrigin::root(), asset_id, xrpl_currency),
 			Error::<Test>::AssetNotSupported
 		);
 	})

--- a/pallet/xrpl-bridge/src/tests.rs
+++ b/pallet/xrpl-bridge/src/tests.rs
@@ -356,7 +356,7 @@ fn submit_currency_transaction_works() {
 			currency,
 		};
 
-		assert_ok!(XRPLBridge::set_xrpl_asset_map(RuntimeOrigin::root(), 4, currency));
+		assert_ok!(XRPLBridge::set_xrpl_asset_map(RuntimeOrigin::root(), 4, Some(currency)));
 		assert_ok!(XRPLBridge::add_relayer(RuntimeOrigin::root(), relayer));
 		assert_ok!(XRPLBridge::submit_transaction(
 			RuntimeOrigin::signed(relayer),
@@ -415,7 +415,7 @@ fn submit_transaction_invalid_issuer_fails() {
 		let mapped_issuer = H160::from_low_u64_be(666);
 		let mapped_currency = XRPLCurrency { symbol, issuer: mapped_issuer };
 
-		assert_ok!(XRPLBridge::set_xrpl_asset_map(RuntimeOrigin::root(), 4, mapped_currency));
+		assert_ok!(XRPLBridge::set_xrpl_asset_map(RuntimeOrigin::root(), 4, Some(mapped_currency)));
 		assert_ok!(XRPLBridge::add_relayer(RuntimeOrigin::root(), relayer));
 		assert_noop!(
 			XRPLBridge::submit_transaction(
@@ -1555,7 +1555,11 @@ fn set_xrpl_asset_map_works() {
 		let xrpl_symbol =
 			XRPLCurrencyType::NonStandard(hex!("524F4F5400000000000000000000000000000000").into());
 		let xrpl_currency = XRPLCurrency { symbol: xrpl_symbol, issuer };
-		assert_ok!(XRPLBridge::set_xrpl_asset_map(RuntimeOrigin::root(), asset_id, xrpl_currency));
+		assert_ok!(XRPLBridge::set_xrpl_asset_map(
+			RuntimeOrigin::root(),
+			asset_id,
+			Some(xrpl_currency)
+		));
 		assert_eq!(AssetIdToXRPL::<Test>::get(asset_id), Some(xrpl_currency));
 		assert_eq!(XRPLToAssetId::<Test>::get(xrpl_currency), Some(asset_id));
 		System::assert_has_event(Event::<Test>::XrplAssetMapSet { asset_id, xrpl_currency }.into());
@@ -1570,7 +1574,11 @@ fn remove_xrpl_asset_map_works() {
 		let xrpl_symbol =
 			XRPLCurrencyType::NonStandard(hex!("524F4F5400000000000000000000000000000000").into());
 		let xrpl_currency = XRPLCurrency { symbol: xrpl_symbol, issuer };
-		assert_ok!(XRPLBridge::set_xrpl_asset_map(RuntimeOrigin::root(), asset_id, xrpl_currency));
+		assert_ok!(XRPLBridge::set_xrpl_asset_map(
+			RuntimeOrigin::root(),
+			asset_id,
+			Some(xrpl_currency)
+		));
 		assert_eq!(AssetIdToXRPL::<Test>::get(asset_id), Some(xrpl_currency));
 		assert_eq!(XRPLToAssetId::<Test>::get(xrpl_currency), Some(asset_id));
 		// remove it by sending second param to none
@@ -1602,7 +1610,7 @@ fn set_xrpl_asset_map_invalid_currency_code() {
 			XRPLCurrencyType::NonStandard(hex!("004F4F5400000000000000000000000000000000").into());
 		let xrpl_currency = XRPLCurrency { symbol: xrpl_symbol, issuer };
 		assert_noop!(
-			XRPLBridge::set_xrpl_asset_map(RuntimeOrigin::root(), asset_id, xrpl_currency),
+			XRPLBridge::set_xrpl_asset_map(RuntimeOrigin::root(), asset_id, Some(xrpl_currency)),
 			Error::<Test>::InvalidCurrencyCode
 		);
 
@@ -1610,7 +1618,7 @@ fn set_xrpl_asset_map_invalid_currency_code() {
 		let xrpl_symbol = XRPLCurrencyType::Standard((*b"XRP").into());
 		let xrpl_currency = XRPLCurrency { symbol: xrpl_symbol, issuer };
 		assert_noop!(
-			XRPLBridge::set_xrpl_asset_map(RuntimeOrigin::root(), asset_id, xrpl_currency),
+			XRPLBridge::set_xrpl_asset_map(RuntimeOrigin::root(), asset_id, Some(xrpl_currency)),
 			Error::<Test>::InvalidCurrencyCode
 		);
 	})
@@ -1626,7 +1634,11 @@ fn set_xrpl_asset_map_not_sudo_fails() {
 			XRPLCurrencyType::NonStandard(hex!("524F4F5400000000000000000000000000000000").into());
 		let xrpl_currency = XRPLCurrency { symbol: xrpl_symbol, issuer };
 		assert_noop!(
-			XRPLBridge::set_xrpl_asset_map(RuntimeOrigin::signed(account), asset_id, xrpl_currency),
+			XRPLBridge::set_xrpl_asset_map(
+				RuntimeOrigin::signed(account),
+				asset_id,
+				Some(xrpl_currency)
+			),
 			BadOrigin
 		);
 	})
@@ -1757,7 +1769,7 @@ fn withdraw_with_payment_delay_using_different_asset_ids_works() {
 				assert_ok!(XRPLBridge::set_xrpl_asset_map(
 					RuntimeOrigin::root(),
 					asset_id,
-					xrpl_currency
+					Some(xrpl_currency)
 				));
 
 				// set initial ticket sequence params
@@ -2863,7 +2875,7 @@ fn process_xrp_tx_for_root_bridging_transaction_low_peg_balance() {
 		assert_ok!(XRPLBridge::set_xrpl_asset_map(
 			RuntimeOrigin::root(),
 			ROOT_ASSET_ID,
-			xrpl_currency
+			Some(xrpl_currency)
 		));
 
 		// submit currency payment tx, balance of peg address is too low so this will fail
@@ -2923,7 +2935,7 @@ fn process_xrp_tx_for_root_bridging_transaction() {
 			assert_ok!(XRPLBridge::set_xrpl_asset_map(
 				RuntimeOrigin::root(),
 				ROOT_ASSET_ID,
-				xrpl_currency
+				Some(xrpl_currency)
 			));
 
 			// submit currency payment tx
@@ -3056,7 +3068,7 @@ mod withdraw_asset {
 				assert_ok!(XRPLBridge::set_xrpl_asset_map(
 					RuntimeOrigin::root(),
 					TEST_ASSET_ID,
-					xrpl_currency
+					Some(xrpl_currency)
 				));
 
 				// set initial ticket sequence params
@@ -3126,7 +3138,7 @@ mod withdraw_asset {
 			assert_ok!(XRPLBridge::set_xrpl_asset_map(
 				RuntimeOrigin::root(),
 				asset_id,
-				xrpl_currency
+				Some(xrpl_currency)
 			));
 
 			// set initial ticket sequence params
@@ -3232,7 +3244,7 @@ mod withdraw_asset {
 				assert_ok!(XRPLBridge::set_xrpl_asset_map(
 					RuntimeOrigin::root(),
 					TEST_ASSET_ID,
-					xrpl_currency
+					Some(xrpl_currency)
 				));
 
 				// set initial ticket sequence params
@@ -3282,7 +3294,7 @@ mod withdraw_asset {
 				assert_ok!(XRPLBridge::set_xrpl_asset_map(
 					RuntimeOrigin::root(),
 					TEST_ASSET_ID,
-					xrpl_currency
+					Some(xrpl_currency)
 				));
 
 				// set initial ticket sequence params
@@ -3331,7 +3343,7 @@ mod withdraw_asset {
 				assert_ok!(XRPLBridge::set_xrpl_asset_map(
 					RuntimeOrigin::root(),
 					TEST_ASSET_ID,
-					xrpl_currency
+					Some(xrpl_currency)
 				));
 
 				// set initial ticket sequence params
@@ -3382,7 +3394,7 @@ mod withdraw_asset {
 				assert_ok!(XRPLBridge::set_xrpl_asset_map(
 					RuntimeOrigin::root(),
 					TEST_ASSET_ID,
-					xrpl_currency
+					Some(xrpl_currency)
 				));
 
 				// set initial ticket sequence params
@@ -3433,7 +3445,7 @@ mod withdraw_asset {
 				assert_ok!(XRPLBridge::set_xrpl_asset_map(
 					RuntimeOrigin::root(),
 					TEST_ASSET_ID,
-					xrpl_currency
+					Some(xrpl_currency)
 				));
 
 				// set initial ticket sequence params
@@ -3486,7 +3498,7 @@ mod withdraw_root {
 				assert_ok!(XRPLBridge::set_xrpl_asset_map(
 					RuntimeOrigin::root(),
 					ROOT_ASSET_ID,
-					xrpl_currency
+					Some(xrpl_currency)
 				));
 
 				// set initial ticket sequence params
@@ -3554,7 +3566,7 @@ mod withdraw_root {
 				assert_ok!(XRPLBridge::set_xrpl_asset_map(
 					RuntimeOrigin::root(),
 					ROOT_ASSET_ID,
-					xrpl_currency
+					Some(xrpl_currency)
 				));
 
 				// set initial ticket sequence params
@@ -3606,7 +3618,7 @@ mod withdraw_root {
 				assert_ok!(XRPLBridge::set_xrpl_asset_map(
 					RuntimeOrigin::root(),
 					ROOT_ASSET_ID,
-					xrpl_currency
+					Some(xrpl_currency)
 				));
 
 				// set initial ticket sequence params
@@ -3668,7 +3680,7 @@ mod withdraw_root {
 				assert_ok!(XRPLBridge::set_xrpl_asset_map(
 					RuntimeOrigin::root(),
 					ROOT_ASSET_ID,
-					xrpl_currency
+					Some(xrpl_currency)
 				));
 
 				// set initial ticket sequence params

--- a/pallet/xrpl-bridge/src/weights.rs
+++ b/pallet/xrpl-bridge/src/weights.rs
@@ -62,7 +62,6 @@ pub trait WeightInfo {
 	fn reset_settled_xrpl_tx_data(i: u32, ) -> Weight;
 	fn prune_settled_ledger_index(i: u32, ) -> Weight;
 	fn set_xrpl_asset_map() -> Weight;
-	fn remove_xrpl_asset_map() -> Weight;
 }
 
 /// Weights for pallet_xrpl_bridge using the Substrate node and recommended hardware.
@@ -262,12 +261,6 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 		Weight::from_all(31_578_000 as u64)
 			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
-	// Storage: `XRPLBridge::XRPLToAssetId` (r:0 w:1)
-	// Storage: `XRPLBridge::AssetIdToXRPL` (r:0 w:1)
-	fn remove_xrpl_asset_map() -> Weight {
-		Weight::from_all(31_578_000 as u64)
-			.saturating_add(T::DbWeight::get().writes(2 as u64))
-	}
 }
 
 // For backwards compatibility and tests
@@ -463,12 +456,6 @@ impl WeightInfo for () {
 	// Storage: `XRPLBridge::AssetIdToXRPL` (r:0 w:1)
 	// Proof: `XRPLBridge::AssetIdToXRPL` (`max_values`: None, `max_size`: Some(53), added: 2528, mode: `MaxEncodedLen`)
 	fn set_xrpl_asset_map() -> Weight {
-		Weight::from_all(31_578_000 as u64)
-			.saturating_add(RocksDbWeight::get().writes(2 as u64))
-	}
-	// Storage: `XRPLBridge::XRPLToAssetId` (r:0 w:1)
-	// Storage: `XRPLBridge::AssetIdToXRPL` (r:0 w:1)
-	fn remove_xrpl_asset_map() -> Weight {
 		Weight::from_all(31_578_000 as u64)
 			.saturating_add(RocksDbWeight::get().writes(2 as u64))
 	}

--- a/pallet/xrpl-bridge/src/weights.rs
+++ b/pallet/xrpl-bridge/src/weights.rs
@@ -62,6 +62,7 @@ pub trait WeightInfo {
 	fn reset_settled_xrpl_tx_data(i: u32, ) -> Weight;
 	fn prune_settled_ledger_index(i: u32, ) -> Weight;
 	fn set_xrpl_asset_map() -> Weight;
+	fn remove_xrpl_asset_map() -> Weight;
 }
 
 /// Weights for pallet_xrpl_bridge using the Substrate node and recommended hardware.
@@ -261,6 +262,12 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 		Weight::from_all(31_578_000 as u64)
 			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
+	// Storage: `XRPLBridge::XRPLToAssetId` (r:0 w:1)
+	// Storage: `XRPLBridge::AssetIdToXRPL` (r:0 w:1)
+	fn remove_xrpl_asset_map() -> Weight {
+		Weight::from_all(31_578_000 as u64)
+			.saturating_add(T::DbWeight::get().writes(2 as u64))
+	}
 }
 
 // For backwards compatibility and tests
@@ -456,6 +463,12 @@ impl WeightInfo for () {
 	// Storage: `XRPLBridge::AssetIdToXRPL` (r:0 w:1)
 	// Proof: `XRPLBridge::AssetIdToXRPL` (`max_values`: None, `max_size`: Some(53), added: 2528, mode: `MaxEncodedLen`)
 	fn set_xrpl_asset_map() -> Weight {
+		Weight::from_all(31_578_000 as u64)
+			.saturating_add(RocksDbWeight::get().writes(2 as u64))
+	}
+	// Storage: `XRPLBridge::XRPLToAssetId` (r:0 w:1)
+	// Storage: `XRPLBridge::AssetIdToXRPL` (r:0 w:1)
+	fn remove_xrpl_asset_map() -> Weight {
 		Weight::from_all(31_578_000 as u64)
 			.saturating_add(RocksDbWeight::get().writes(2 as u64))
 	}


### PR DESCRIPTION
Extrinsic to remove mapping from assetIdToXRPL in xrplBridge pallet.