### PR TITLE
TRN-212 Exclude non-owner proxied FP transactions

### DIFF
--- a/pallet/futurepass/src/mock.rs
+++ b/pallet/futurepass/src/mock.rs
@@ -63,6 +63,8 @@ impl InstanceFilter<RuntimeCall> for ProxyType {
 			) {
 				return false;
 			}
+
+			return self == &ProxyType::Owner;
 		}
 		match self {
 			_ => true,

--- a/pallet/futurepass/src/tests.rs
+++ b/pallet/futurepass/src/tests.rs
@@ -1694,7 +1694,7 @@ fn cannot_bypass_proxy_extrinsic_via_proxy() {
 				RuntimeOrigin::signed(delegate),
 				futurepass,
 				None,
-				inner_call
+				inner_call.clone()
 			));
 
 			// the delegate tried to transfer the futurepass, but because it was
@@ -1702,6 +1702,15 @@ fn cannot_bypass_proxy_extrinsic_via_proxy() {
 			// owner
 			assert_eq!(futurepass, Holders::<Test>::get(&owner).unwrap());
 			assert!(Holders::<Test>::get(&other).is_none());
+
+			// validate the owner is still able to make whitelisted proxy calls
+			assert_ok!(pallet_proxy::Pallet::<Test>::proxy(
+				RuntimeOrigin::signed(owner),
+				futurepass,
+				None,
+				inner_call
+			));
+			assert_eq!(futurepass, Holders::<Test>::get(&other).unwrap());
 		});
 }
 

--- a/runtime/src/impls.rs
+++ b/runtime/src/impls.rs
@@ -786,6 +786,10 @@ impl InstanceFilter<RuntimeCall> for ProxyType {
 			) {
 				return false;
 			}
+
+			// the whitelisted calls above should only be able to be called by
+			// the owner of the futurepass
+			return self == &ProxyType::Owner;
 		}
 		match self {
 			ProxyType::Owner => true,


### PR DESCRIPTION
https://www.notion.so/futureverse/FRN-25-Privilege-system-non-functional-30ab4c8692b742659f43be471517d286

The privilege check within `Futurepas::proxy_extrinsic` are non-functional as they can be bypassed by calling `Proxy::proxy` using a delegate of the FP account.

In particular, a Futurepass account will have an `Owner` and also zero or more delegates. The owner and delegate accounts can perform extrinsics on behalf of the futurepass account via proxy extrinsics. There are two ways to do this:

1. Invoking the `Futurepass::proxy_extrinsic` call
2. Or directly calling `Proxy::proxy`

The `Futurepass::proxy_extrinsic` call has a guard that prevents certain extrinsics from being executed unless the proxy caller is the owner of the Futurepass. These in particular are
* `Futurepass::register_delegate_with_signature`
* `Futurepass::unregister_delegate`
* `Futurepass::transfer_futurepass`
Effectively, we only want the owner to be able to invoke the above extrinsics (a delegate can call `unregister_delegate` but should call directly, not proxied). However a delegate account can bypass this protection by calling `Proxy::proxy` directly.

This allows for an unwanted case such as a delegate account being able to invoke `transfer_futurepass`.

To prevent this, we update the `InstanceFilter` impl to only allow the `Owner` `ProxyType` to make certain proxy calls. The `filter` implementation will not execute any proxy transactions if they are one of the listed extrinsics, and the `ProxyType` is not of the [Owner](https://github.com/futureversecom/trn-seed/blob/main/runtime/src/impls.rs#L702) variant.

The filter first checks if the `proxy` call is calling another `proxy` extrinsic or a `futurepass` extrinsic. In this case only the `register_delegate_with_signature`, `unregister_delegate`, and `transfer_futurepass` extrinsics are allowed. We the additionally ensure that the `ProxyType` is of `Owner`

```
if matches!(c, RuntimeCall::Proxy(..) | RuntimeCall::Futurepass(..)) {
		// Whitelist currently includes
		// pallet_futurepass::Call::register_delegate_with_signature,
		// pallet_futurepass::Call::unregister_delegate
		if !matches!(
			c,
			RuntimeCall::Futurepass(
				pallet_futurepass::Call::register_delegate_with_signature { .. }
			) | RuntimeCall::Futurepass(pallet_futurepass::Call::unregister_delegate { .. })
				| RuntimeCall::Futurepass(pallet_futurepass::Call::transfer_futurepass { .. })
		) {
			return false;
		}

		return self == &ProxyType::Owner;
}
```