### PR TITLE
TRN-382 Prevent EthCallNotarization Resubmission

### DIFF
--- a/pallet/ethy/src/impls.rs
+++ b/pallet/ethy/src/impls.rs
@@ -545,7 +545,7 @@ impl<T: Config> Pallet<T> {
 	}
 
 	/// Send a notarization for the given claim
-	fn offchain_send_notarization(
+	pub(crate) fn offchain_send_notarization(
 		key: &T::EthyId,
 		payload: NotarizationPayload,
 	) -> Result<(), Error<T>> {
@@ -983,50 +983,6 @@ impl<T: Config> Pallet<T> {
 		);
 		<frame_system::Pallet<T>>::deposit_log(log);
 		Self::deposit_event(Event::<T>::EventSend { event_proof_id, signing_request: request });
-	}
-}
-
-impl<T: Config> frame_support::unsigned::ValidateUnsigned for Pallet<T> {
-	type Call = Call<T>;
-
-	fn validate_unsigned(_source: TransactionSource, call: &Self::Call) -> TransactionValidity {
-		if let Call::submit_notarization { ref payload, ref signature } = call {
-			// notarization must be from an active notary
-			let notary_keys = NotaryKeys::<T>::get();
-			let notary_public_key = match notary_keys.get(payload.authority_index() as usize) {
-				Some(id) => id,
-				None => return InvalidTransaction::BadProof.into(),
-			};
-			// notarization must not be a duplicate/equivocation
-			if <EventNotarizations<T>>::contains_key(payload.payload_id(), &notary_public_key) {
-				log!(
-					error,
-					"💎 received equivocation from: {:?} on {:?}",
-					notary_public_key,
-					payload.payload_id()
-				);
-				return InvalidTransaction::BadProof.into();
-			}
-			// notarization is signed correctly
-			if !(notary_public_key.verify(&payload.encode(), signature)) {
-				return InvalidTransaction::BadProof.into();
-			}
-			ValidTransaction::with_tag_prefix("eth-bridge")
-				.priority(UNSIGNED_TXS_PRIORITY)
-				// 'provides' must be unique for each submission on the network (i.e. unique for
-				// each claim id and validator)
-				.and_provides([
-					b"notarize",
-					&payload.type_id().to_be_bytes(),
-					&payload.payload_id().to_be_bytes(),
-					&(payload.authority_index() as u64).to_be_bytes(),
-				])
-				.longevity(3)
-				.propagate(true)
-				.build()
-		} else {
-			InvalidTransaction::Call.into()
-		}
 	}
 }
 


### PR DESCRIPTION
This PR is to specifically address the audit issue [FRN-37](https://www.notion.so/futureverse/FRN-37-Resubmission-of-EthCallNotarizations-b2705f96fdbf44d6b9f34785e8e2e2a4).

The audit ticket describes a vulnerability where `EthCallNotarizations` can be resubmitted, potentially allowing a single notary to affect the outcome of an eth call notarization. Within the implementation of `submit_notarization`, the notarization is persisted in storage, but there is additional validation to ensure that a submission has not already been submitted. It has also been noted that for EventNotarizations, there is sufficient validation to prevent resubmission.

To remedy this, we follow the same logic as `EventNotarizations` does, where within the `validate_unsigned` implementation, we check the storage to ensure the notarization has not been resubmitted.

**NOTE**

This PR is effectively non-functional. Notarization submissions do not actually occur in production, as `submit_notarization` is only triggered in the cases:
1. Where an event notarization for an eth tx that has been challenged, which will never happen though because we have blocked the challenge functionality. Check out the call filter [here](https://github.com/futureversecom/trn-seed/blob/c2825fef61988ddf6f71b2892c59946c589fbd25/runtime/src/lib.rs#L241), which prevents these calls from executing
2. For call notarizations which isn't hooked as the eth-state-oracle was not brought along when this repo transitioned from Cennznet -> TRN

Furthermore, the `UnsignedValidator` was not correctly implemented for the ethy-pallet as it was missing the `#[pallet::validate_unsigned]` proc macro. This means that unsigned extrinsics being sent to the ethy-pallet were never correctly validated in the first place.

The only value of merging this PR is to:
1. Say that we addressed the audit problem (ticking boxes essentially)
2. Ensure that we have addressed this problem once we do eventually reintroduce decentralized notarizatios and/or the eth-state-oracle

A more long term solution would involve refactoring the ethy-pallet in it's entirety ([started here](https://github.com/futureversecom/trn-seed/pull/441)).