### PR TITLE
TRN-609 Improve `transact` error handling

### DIFF
--- a/pallet/doughnut/src/test.rs
+++ b/pallet/doughnut/src/test.rs
@@ -906,7 +906,7 @@ fn signed_extension_validations_low_balance_fails() {
 			tip: 0,
 			signature: vec![],
 		};
-		let outer_signature = holder.sign_ecdsa(&outer_call.encode().as_slice());
+		let outer_signature = holder.sign_eip191(&outer_call.encode().as_slice());
 
 		// validate self contained extrinsic is invalid (invalid signature)
 		let xt: mock::UncheckedExtrinsicT = fp_self_contained::UncheckedExtrinsic::new_unsigned(
@@ -928,7 +928,7 @@ fn signed_extension_validations_low_balance_fails() {
 				xt.clone().into(),
 				H256::default()
 			),
-			TransactionValidityError::Invalid(InvalidTransaction::BadProof)
+			TransactionValidityError::Invalid(InvalidTransaction::Payment)
 		);
 	});
 }

--- a/pallet/xrpl/src/lib.rs
+++ b/pallet/xrpl/src/lib.rs
@@ -143,57 +143,60 @@ where
 		len: usize,
 	) -> Option<TransactionValidity> {
 		if let Call::transact { encoded_msg, signature, call } = self {
-			let (nonce, tip) = validate_params::<T>(encoded_msg.as_bytes_ref(), signature.as_bytes_ref(), call)
-				.map_err(|e| {
-					log!(info, "⛔️ validate_self_contained: failed to validate params: {:?}", e);
-					InvalidTransaction::Call
-				})
-				.ok()?;
+			let validate = || -> TransactionValidity {
+				let (nonce, tip) = validate_params::<T>(encoded_msg.as_bytes_ref(), signature.as_bytes_ref(), call)
+					.map_err(|e| {
+						log!(info, "⛔️ validate_self_contained: failed to validate params: {:?}", e);
+						InvalidTransaction::Call
+					})?;
 
-			let validations: XRPLValidations<T> = (
-				CheckNonZeroSender::new(),
-				CheckSpecVersion::<T>::new(),
-				CheckTxVersion::<T>::new(),
-				CheckEra::<T>::from(Era::immortal()),
-				CheckWeight::new(),
-				ChargeTransactionPayment::<T>::from(tip.into()),
-			);
+				let validations: XRPLValidations<T> = (
+					CheckNonZeroSender::new(),
+					CheckSpecVersion::<T>::new(),
+					CheckTxVersion::<T>::new(),
+					CheckEra::<T>::from(Era::immortal()),
+					CheckWeight::new(),
+					ChargeTransactionPayment::<T>::from(tip.into()),
+				);
 
-			let mut tx_origin = T::AccountId::from(*origin);
+				let mut tx_origin = T::AccountId::from(*origin);
 
-			// validate signed extensions using origin
-			SignedExtension::validate(&validations, &tx_origin, &(*call.clone()).into(), dispatch_info, len).ok()?;
+				// validate signed extensions using origin
+				SignedExtension::validate(&validations, &tx_origin, &(*call.clone()).into(), dispatch_info, len)?;
 
-			// validate signed extensions using EOA - for futurepass based transactions
-			if <T as pallet::Config>::FuturepassLookup::check_extrinsic(&call, &()) {
-				// this implies that the origin is futurepass address; we need to get the EOA associated with it
-				let eoa = <T as pallet::Config>::FuturepassLookup::unlookup(*origin);
-				if eoa == H160::zero() {
-					log!(info, "⛔️ failed to get EOA from futurepass address");
-					return None;
+				// validate signed extensions using EOA - for futurepass based transactions
+				if <T as pallet::Config>::FuturepassLookup::check_extrinsic(&call, &()) {
+					// this implies that the origin is futurepass address; we need to get the EOA associated with it
+					let eoa = <T as pallet::Config>::FuturepassLookup::unlookup(*origin);
+					if eoa == H160::zero() {
+						log!(info, "⛔️ failed to get EOA from futurepass address");
+						// return None;
+					}
+					tx_origin = T::AccountId::from(eoa);
 				}
-				tx_origin = T::AccountId::from(eoa);
-			}
 
-			// validate nonce signed extension using EOA
-			let validations: EOANonceValidation<T> = (CheckNonce::from(nonce.into()),);
-			SignedExtension::validate(&validations, &tx_origin, &(*call.clone()).into(), dispatch_info, len).ok()?;
+				// validate nonce signed extension using EOA
+				let validations: EOANonceValidation<T> = (CheckNonce::from(nonce.into()),);
+				SignedExtension::validate(&validations, &tx_origin, &(*call.clone()).into(), dispatch_info, len)?;
 
-			// priority is based on the provided tip in the xrpl transaction data
-			let priority = ChargeTransactionPayment::<T>::get_priority(&dispatch_info, len, tip.into(), 0.into());
-			let who: T::AccountId = (tx_origin).clone().into();
-			let account = frame_system::Account::<T>::get(who);
-			let mut builder =
-				ValidTransactionBuilder::default().and_provides((tx_origin.clone(), nonce)).priority(priority);
+				// priority is based on the provided tip in the xrpl transaction data
+				let priority = ChargeTransactionPayment::<T>::get_priority(&dispatch_info, len, tip.into(), 0.into());
+				let who: T::AccountId = (tx_origin).clone().into();
+				let account = frame_system::Account::<T>::get(who);
+				let mut builder =
+					ValidTransactionBuilder::default().and_provides((tx_origin.clone(), nonce)).priority(priority);
 
-			// in the context of the pool, a transaction with too high a nonce is still considered valid
-			if nonce > account.nonce.into() {
-				if let Some(prev_nonce) = nonce.checked_sub(1) {
-					builder = builder.and_requires((tx_origin, prev_nonce))
+				// in the context of the pool, a transaction with too high a nonce is still considered valid
+				if nonce > account.nonce.into() {
+					if let Some(prev_nonce) = nonce.checked_sub(1) {
+						builder = builder.and_requires((tx_origin, prev_nonce))
+					}
 				}
-			}
 
-			Some(builder.build())
+				builder.build()
+			};
+
+			Some(validate())
 		} else {
 			None
 		}

--- a/pallet/xrpl/src/lib.rs
+++ b/pallet/xrpl/src/lib.rs
@@ -170,7 +170,7 @@ where
 					let eoa = <T as pallet::Config>::FuturepassLookup::unlookup(*origin);
 					if eoa == H160::zero() {
 						log!(info, "⛔️ failed to get EOA from futurepass address");
-						// return None;
+						return Err(TransactionValidityError::Invalid(InvalidTransaction::BadProof));
 					}
 					tx_origin = T::AccountId::from(eoa);
 				}

--- a/pallet/xrpl/src/tests.rs
+++ b/pallet/xrpl/src/tests.rs
@@ -64,7 +64,7 @@ mod self_contained_call {
 				}));
 				assert_err!(
 					Executive::validate_transaction(TransactionSource::External, xt.into(), H256::default()),
-					TransactionValidityError::Invalid(InvalidTransaction::BadProof),
+					TransactionValidityError::Invalid(InvalidTransaction::Call),
 				);
 			});
 	}
@@ -115,7 +115,7 @@ mod self_contained_call {
 				}));
 				assert_err!(
 					Executive::validate_transaction(TransactionSource::External, xt.into(), H256::default()),
-					TransactionValidityError::Invalid(InvalidTransaction::BadProof),
+					TransactionValidityError::Invalid(InvalidTransaction::Call),
 				);
 			});
 	}
@@ -139,7 +139,7 @@ mod self_contained_call {
 				}));
 				assert_err!(
 					Executive::validate_transaction(TransactionSource::External, xt.clone().into(), H256::default()),
-					TransactionValidityError::Invalid(InvalidTransaction::BadProof),
+					TransactionValidityError::Invalid(InvalidTransaction::Call),
 				);
 
 				// validate self contained extrinsic is invalid (invalid signature)
@@ -150,7 +150,7 @@ mod self_contained_call {
 				}));
 				assert_err!(
 					Executive::validate_transaction(TransactionSource::External, xt.clone().into(), H256::default()),
-					TransactionValidityError::Invalid(InvalidTransaction::BadProof),
+					TransactionValidityError::Invalid(InvalidTransaction::Call),
 				);
 
 				// validate self contained extrinsic fails, user does not have funds to pay for transaction (corrected signature)
@@ -161,7 +161,7 @@ mod self_contained_call {
 				}));
 				assert_err!(
 					Executive::validate_transaction(TransactionSource::External, xt.clone().into(), H256::default()),
-					TransactionValidityError::Invalid(InvalidTransaction::BadProof),
+					TransactionValidityError::Invalid(InvalidTransaction::Payment),
 				);
 				// validate same transaction is successful after funding caller
 				let tx = XRPLTransaction::try_from(tx_bytes.as_bytes_ref()).unwrap();
@@ -201,7 +201,7 @@ mod self_contained_call {
 				System::set_block_number(10);
 				assert_err!(
 					Executive::validate_transaction(TransactionSource::External, xt.clone().into(), H256::default()),
-					TransactionValidityError::Invalid(InvalidTransaction::BadProof),
+					TransactionValidityError::Invalid(InvalidTransaction::Call),
 				);
 
 				// reset block number, extrinsic validation should pass now
@@ -241,7 +241,7 @@ mod self_contained_call {
 				// validate the same extrinsic will fail (nonce mismatch) - preventing replays
 				assert_err!(
 					Executive::validate_transaction(TransactionSource::External, xt.clone().into(), H256::default()),
-					TransactionValidityError::Invalid(InvalidTransaction::BadProof),
+					TransactionValidityError::Invalid(InvalidTransaction::Stale),
 				);
   		});
 	}
@@ -275,7 +275,7 @@ mod self_contained_call {
 				System::set_block_number(10);
 				assert_err!(
 					Executive::validate_transaction(TransactionSource::External, xt.clone().into(), H256::default()),
-					TransactionValidityError::Invalid(InvalidTransaction::BadProof),
+					TransactionValidityError::Invalid(InvalidTransaction::Call),
 				);
 
 				// reset block number, extrinsic validation should pass now
@@ -315,7 +315,7 @@ mod self_contained_call {
 				// validate the same extrinsic will fail (nonce mismatch) - preventing replays
 				assert_err!(
 					Executive::validate_transaction(TransactionSource::External, xt.clone().into(), H256::default()),
-					TransactionValidityError::Invalid(InvalidTransaction::BadProof),
+					TransactionValidityError::Invalid(InvalidTransaction::Stale),
 				);
   		});
 	}


### PR DESCRIPTION
Front-end developers often encountered a misleading error message `1010: Invalid Transaction: Transaction has a bad signature` when working the `xrpl` pallet. This would usually be due to an unrelated problem, such as the sending account not having sufficient balance to pay for the extrinsic. Seeing the incorrect error message could be very confusing.  

The above error message is correlated with the error `InvalidTransaction::BadProof`. The runtime would mistakingly return this error because the `xrpl` (and `doughnut`) pallet have additional extrinsic validation applied to their runtime calls, implemented via the [SelfContainedCall](https://github.com/polkadot-evm/frontier/blob/master/primitives/self-contained/src/lib.rs#L36) trait that was returning the wrong value. The method `validate_self_contained` returns a type `Option<TransactionValidityError>`, where if the return value was `None`, the `validate` implementation for CheckedExtrinsics from evm frontier would default to `InvalidTransaction::BadProof` https://github.com/polkadot-evm/frontier/blob/master/primitives/self-contained/src/checked_extrinsic.rs#L93-L95.

This PR aims to ensure the correct `InvalidTransaction` variant is propagated when the runtime call is validated.

## Release Notes

### Error Messages:
#### Changed:
doughtnut: Invalid transactions should be correct variant instead of catch-all `BadProof`
xrpl: Invalid transactions should be correct variant instead of catch-all `BadProof`