### PR TITLE
EIP2470 fix

### DIFF
--- a/runtime/src/migrations/evm.rs
+++ b/runtime/src/migrations/evm.rs
@@ -73,7 +73,8 @@ impl OnRuntimeUpgrade for Upgrade {
 		let mut weight = <Runtime as frame_system::Config>::DbWeight::get().reads(3);
 
 		let eip2470_factory = H160::from_str(EIP2470_CONTRACT_ADDRESS).unwrap();
-		if !EVM::is_account_empty(&eip2470_factory) {
+		let factory_code_len = <pallet_evm::AccountCodes<Runtime>>::decode_len(&eip2470_factory).unwrap_or(0);
+		if factory_code_len != 0 {
 			log::info!(target: "Migration", "EIP-2470 factory already exists, skipping migration");
 			return weight;
 		}

--- a/runtime/src/migrations/evm.rs
+++ b/runtime/src/migrations/evm.rs
@@ -73,7 +73,8 @@ impl OnRuntimeUpgrade for Upgrade {
 		let mut weight = <Runtime as frame_system::Config>::DbWeight::get().reads(3);
 
 		let eip2470_factory = H160::from_str(EIP2470_CONTRACT_ADDRESS).unwrap();
-		let factory_code_len = <pallet_evm::AccountCodes<Runtime>>::decode_len(&eip2470_factory).unwrap_or(0);
+		let factory_code_len =
+			<pallet_evm::AccountCodes<Runtime>>::decode_len(&eip2470_factory).unwrap_or(0);
 		if factory_code_len != 0 {
 			log::info!(target: "Migration", "EIP-2470 factory already exists, skipping migration");
 			return weight;

--- a/runtime/src/migrations/evm.rs
+++ b/runtime/src/migrations/evm.rs
@@ -72,9 +72,9 @@ impl OnRuntimeUpgrade for Upgrade {
 		// reading factory deployer
 		let mut weight = <Runtime as frame_system::Config>::DbWeight::get().reads(3);
 
-		let factory_deployer = H160::from_str(EIP2470_EOA_ADDRESS).unwrap();
-		if !EVM::is_account_empty(&factory_deployer) {
-			log::info!(target: "Migration", "Factory deployer already exists, skipping migration");
+		let eip2470_factory = H160::from_str(EIP2470_CONTRACT_ADDRESS).unwrap();
+		if !EVM::is_account_empty(&eip2470_factory) {
+			log::info!(target: "Migration", "EIP-2470 factory already exists, skipping migration");
 			return weight;
 		}
 


### PR DESCRIPTION
## Changelog

Using factory address to check empty contract - instead of an EOA since it may have funds (is not empty)