### PR TITLE
Release 8.61.0

### DIFF
--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -158,7 +158,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("root"),
 	impl_name: create_runtime_str!("root"),
 	authoring_version: 1,
-	spec_version: 60,
+	spec_version: 61,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 11,

--- a/runtime/src/migrations/evm.rs
+++ b/runtime/src/migrations/evm.rs
@@ -70,7 +70,7 @@ impl OnRuntimeUpgrade for Upgrade {
 		log::info!(target: "Migration", "🛠️ EVM: creating EIP-2470 factory deployer and factory contract 🛠️");
 
 		// reading factory deployer
-		let mut weight = <Runtime as frame_system::Config>::DbWeight::get().reads(3);
+		let mut weight = <Runtime as frame_system::Config>::DbWeight::get().reads(1);
 
 		let eip2470_factory = H160::from_str(EIP2470_CONTRACT_ADDRESS).unwrap();
 		let factory_code_len =
@@ -159,10 +159,10 @@ pub mod v1 {
 	where
 		<Runtime as frame_system::Config>::AccountId: From<H160>,
 	{
-		let mut weight = <Runtime as frame_system::Config>::DbWeight::get().reads(6);
+		let mut weight = <Runtime as frame_system::Config>::DbWeight::get().reads(3);
 
-		// r: 3 + 3, w: 0
-		if !(EVM::is_account_empty(&deployer_eoa) && EVM::is_account_empty(&contract_address)) {
+		// r: 3, w: 0
+		if !EVM::is_account_empty(&contract_address) {
 			log::info!(target: "Migration", "No migration was done, however migration code needs to be removed.");
 			return weight;
 		}
@@ -233,11 +233,11 @@ pub mod v1 {
 				Upgrade::post_upgrade(pre_upgrade_state).expect("Post-upgrade should succeed");
 
 				// Validate future runtime upgrade fails
-				// 3 reads for factory deployer check only
+				// 1 read for factory check only
 				let new_weight = Upgrade::on_runtime_upgrade();
 				assert_eq!(
 					new_weight,
-					<Runtime as frame_system::Config>::DbWeight::get().reads(3),
+					<Runtime as frame_system::Config>::DbWeight::get().reads(1),
 					"Migration weight mismatch"
 				);
 			});


### PR DESCRIPTION
# Release

**Release Name:** `8.61.0`

**Spec Version:** `61`

**Client Version:** `8.0.0`

## Key Changes:

This release introduces the following changes:
- Fix for runtime migration to deploy [EIP-2470](https://eips.ethereum.org/EIPS/eip-2470) and [Universal deployer](https://gist.github.com/Agusx1211/de05dabf918d448d315aa018e2572031) via a runtime upgrade
  - A bugfix is included as a commit to remove additional checks which prevent internal migration code from executing; this also reduces migration weight

## PRs included:
- https://github.com/futureversecom/trn-seed/pull/894

---

## Client Changes:
- [ ] Yes
- [x] No

## Runtime Changes:
- [x] Yes
- [ ] No

### Storage Migrations:
#### Added:
- EVM: Runtime migration fix for re-execution
