### PR TITLE
XRPL alt token bridge with Destination Tag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6623,8 +6623,6 @@ dependencies = [
  "seed-pallet-common",
  "seed-primitives",
  "sp-core",
- "sp-io",
- "sp-keystore",
  "sp-runtime",
  "sp-std",
  "xrpl-codec",
@@ -12175,7 +12173,7 @@ dependencies = [
 [[package]]
 name = "xrpl-codec"
 version = "0.2.3"
-source = "git+https://github.com/futureversecom/xrpl-tx-codec#1af5e9fbbe3695f9d7711ec823edc8631e94a40f"
+source = "git+https://github.com/futureversecom/xrpl-tx-codec#fcf088ef4af985254fcfcb947b6850728c2aced8"
 dependencies = [
  "ripemd",
  "sha2 0.10.8",
@@ -12185,7 +12183,7 @@ dependencies = [
 [[package]]
 name = "xrpl-codec-utils"
 version = "0.1.0"
-source = "git+https://github.com/futureversecom/xrpl-tx-codec#1af5e9fbbe3695f9d7711ec823edc8631e94a40f"
+source = "git+https://github.com/futureversecom/xrpl-tx-codec#fcf088ef4af985254fcfcb947b6850728c2aced8"
 dependencies = [
  "hashbrown 0.12.3",
  "lazy_static",

--- a/pallet/xrpl-bridge/Cargo.toml
+++ b/pallet/xrpl-bridge/Cargo.toml
@@ -32,8 +32,6 @@ seed-primitives = { workspace = true }
 seed-pallet-common = { workspace = true }
 
 [dev-dependencies]
-sp-io = { workspace = true }
-sp-keystore = { workspace = true }
 pallet-nft = { workspace = true }
 
 [features]

--- a/pallet/xrpl-bridge/src/lib.rs
+++ b/pallet/xrpl-bridge/src/lib.rs
@@ -51,7 +51,7 @@ use xrpl_codec::{
 	traits::BinarySerialize,
 	transaction::{
 		NFTokenAcceptOffer, NFTokenCreateOffer, Payment, PaymentAltCurrency,
-		PaymentWithDestinationTag, SignerListSet,
+		PaymentWithDestinationTag, SignerListSet, PaymentAltCurrencyWithDestinationTag
 	},
 	types::{AccountIdType, AmountType, IssuedAmountType, IssuedValueType},
 };
@@ -1559,7 +1559,7 @@ impl<T: Config> Pallet<T> {
 	fn serialize_asset_tx(
 		tx_data: AssetWithdrawTransaction,
 		door_address: [u8; 20],
-		_destination_tag: Option<u32>,
+		destination_tag: Option<u32>,
 	) -> Result<Vec<u8>, DispatchError> {
 		let AssetWithdrawTransaction {
 			tx_fee,
@@ -1583,18 +1583,33 @@ impl<T: Config> Pallet<T> {
 			IssuedAmountType::from_issued_value(value_type, currency.into(), issuer)
 				.map_err(|_| Error::<T>::InvalidCurrencyCode)?;
 		let amount: Amount = Amount(AmountType::Issued(issued_amount));
-		let payment = PaymentAltCurrency::new(
-			door_address,
-			destination.into(),
-			amount,
-			tx_nonce,
-			tx_ticket_sequence,
-			tx_fee,
-			SourceTag::<T>::get(),
-			// omit signer key since this is a 'MultiSigner' tx
-			None,
-		);
-		Ok(payment.binary_serialize(true))
+		let tx_blob = if let Some(destination_tag) = destination_tag {
+			PaymentAltCurrencyWithDestinationTag::new(
+				door_address,
+				destination.into(),
+				amount,
+				tx_nonce,
+				tx_ticket_sequence,
+				tx_fee,
+				SourceTag::<T>::get(),
+				destination_tag,
+				// omit signer key since this is a 'MultiSigner' tx
+				None,
+			).binary_serialize(true)
+		} else {
+			PaymentAltCurrency::new(
+				door_address,
+				destination.into(),
+				amount,
+				tx_nonce,
+				tx_ticket_sequence,
+				tx_fee,
+				SourceTag::<T>::get(),
+				// omit signer key since this is a 'MultiSigner' tx
+				None,
+			).binary_serialize(true)
+		};
+		Ok(tx_blob)
 	}
 
 	/// Saturate the balance so that we don't lose precision when we later convert it to

--- a/pallet/xrpl-bridge/src/lib.rs
+++ b/pallet/xrpl-bridge/src/lib.rs
@@ -51,7 +51,7 @@ use xrpl_codec::{
 	traits::BinarySerialize,
 	transaction::{
 		NFTokenAcceptOffer, NFTokenCreateOffer, Payment, PaymentAltCurrency,
-		PaymentWithDestinationTag, SignerListSet, PaymentAltCurrencyWithDestinationTag
+		PaymentAltCurrencyWithDestinationTag, PaymentWithDestinationTag, SignerListSet,
 	},
 	types::{AccountIdType, AmountType, IssuedAmountType, IssuedValueType},
 };
@@ -1595,7 +1595,8 @@ impl<T: Config> Pallet<T> {
 				destination_tag,
 				// omit signer key since this is a 'MultiSigner' tx
 				None,
-			).binary_serialize(true)
+			)
+			.binary_serialize(true)
 		} else {
 			PaymentAltCurrency::new(
 				door_address,
@@ -1607,7 +1608,8 @@ impl<T: Config> Pallet<T> {
 				SourceTag::<T>::get(),
 				// omit signer key since this is a 'MultiSigner' tx
 				None,
-			).binary_serialize(true)
+			)
+			.binary_serialize(true)
 		};
 		Ok(tx_blob)
 	}

--- a/pallet/xrpl-bridge/src/tests.rs
+++ b/pallet/xrpl-bridge/src/tests.rs
@@ -3526,7 +3526,7 @@ mod withdraw_asset {
 						amount: initial_balance,
 						destination: destination.clone(),
 					}
-						.into(),
+					.into(),
 				);
 			})
 	}

--- a/pallet/xrpl-bridge/src/tests.rs
+++ b/pallet/xrpl-bridge/src/tests.rs
@@ -3464,6 +3464,74 @@ mod withdraw_asset {
 	}
 
 	#[test]
+	fn withdraw_asset_with_destination_tag_works() {
+		const TEST_ASSET_ID: u32 = 5;
+		let initial_balance = 2000;
+		TestExt::<Test>::default()
+			.with_asset(TEST_ASSET_ID, "TEST", &[(alice(), initial_balance)])
+			.build()
+			.execute_with(|| {
+				// For this test we will set the door_tx_fee to 0
+				assert_ok!(XRPLBridge::set_door_tx_fee(
+					frame_system::RawOrigin::Root.into(),
+					XRPLDoorAccount::Main,
+					0_u64
+				));
+				let door = XrplAccountId::from_slice(b"5490B68F2d16B3E87cba");
+
+				// Setup the asset map
+				let issuer = XrplAccountId::from_slice(b"6490B68F1116BFE87DDD");
+				let currency = XRPLCurrencyType::NonStandard(
+					hex!("524F4F5400000000000000000000000000000000").into(),
+				);
+				let xrpl_currency = XRPLCurrency { symbol: currency, issuer };
+				assert_ok!(XRPLBridge::set_xrpl_asset_map(
+					RuntimeOrigin::root(),
+					TEST_ASSET_ID,
+					Some(xrpl_currency)
+				));
+
+				// set initial ticket sequence params
+				assert_ok!(XRPLBridge::set_ticket_sequence_current_allocation(
+					RuntimeOrigin::root(),
+					XRPLDoorAccount::Main,
+					1_u32,
+					1_u32,
+					200_u32
+				));
+				assert_ok!(XRPLBridge::set_door_address(
+					RuntimeOrigin::root(),
+					XRPLDoorAccount::Main,
+					Some(door)
+				));
+
+				// Withdraw full amount
+				let destination = XrplAccountId::from_slice(b"6490B68F1116BFE87DDD");
+				let destination_tag = 1234;
+				assert_ok!(XRPLBridge::withdraw(
+					RuntimeOrigin::signed(alice()),
+					TEST_ASSET_ID,
+					initial_balance,
+					destination,
+					Some(destination_tag)
+				));
+				assert_eq!(AssetsExt::balance(TEST_ASSET_ID, &alice()), 0);
+
+				// Ensure event is thrown
+				System::assert_last_event(
+					Event::<Test>::WithdrawRequest {
+						proof_id: 0,
+						sender: alice(),
+						asset_id: TEST_ASSET_ID,
+						amount: initial_balance,
+						destination: destination.clone(),
+					}
+						.into(),
+				);
+			})
+	}
+
+	#[test]
 	fn withdraw_asset_no_asset_map_fails() {
 		const TEST_ASSET_ID: u32 = 5;
 		let initial_balance = 2000;


### PR DESCRIPTION
# Description

- Adds support for bridging Alt tokens to XRPL with destination tag. This is not a breaking change as the extrinsic already supports the optional destination tag parameter

## Context & Background

- A user has requested bridging alt tokens with destination tag however it is not currently working

## Notes & Additional Information

- requires [PR](https://github.com/futureversecom/xrpl-tx-codec/pull/21) on XRPL-codec to be merged first.

## Related Issues

- https://futureverse.atlassian.net/browse/TRN-701?atlOrigin=eyJpIjoiNjEzNGRjZGU3NTg5NDFkYzkyN2VhOWRiNTQ4ODNkZjAiLCJwIjoiaiJ9

