### PR TITLE
Remove Storage getters from pallets

### DIFF
--- a/evm-precompiles/erc1155/src/lib.rs
+++ b/evm-precompiles/erc1155/src/lib.rs
@@ -322,7 +322,7 @@ where
 		let operator: Runtime::AccountId = H160::from(operator).into();
 
 		handle.record_cost(RuntimeHelper::<Runtime>::db_read_gas_cost())?;
-		let is_approved = pallet_token_approvals::Pallet::<Runtime>::erc1155_approvals_for_all(
+		let is_approved = pallet_token_approvals::ERC1155ApprovalsForAll::<Runtime>::get(
 			owner,
 			(collection_id, operator),
 		)
@@ -582,7 +582,7 @@ where
 		// Check approvals
 		if from != handle.context().caller {
 			handle.record_cost(RuntimeHelper::<Runtime>::db_read_gas_cost())?;
-			let is_approved = pallet_token_approvals::Pallet::<Runtime>::erc1155_approvals_for_all(
+			let is_approved = pallet_token_approvals::ERC1155ApprovalsForAll::<Runtime>::get(
 				Runtime::AccountId::from(from),
 				(collection_id, Runtime::AccountId::from(handle.context().caller)),
 			)
@@ -629,7 +629,7 @@ where
 		// Check approvals
 		if operator != handle.context().caller {
 			handle.record_cost(RuntimeHelper::<Runtime>::db_read_gas_cost())?;
-			let is_approved = pallet_token_approvals::Pallet::<Runtime>::erc1155_approvals_for_all(
+			let is_approved = pallet_token_approvals::ERC1155ApprovalsForAll::<Runtime>::get(
 				Runtime::AccountId::from(operator),
 				(collection_id, Runtime::AccountId::from(handle.context().caller)),
 			)
@@ -697,7 +697,7 @@ where
 		// Check approvals
 		if operator != handle.context().caller {
 			handle.record_cost(RuntimeHelper::<Runtime>::db_read_gas_cost())?;
-			let is_approved = pallet_token_approvals::Pallet::<Runtime>::erc1155_approvals_for_all(
+			let is_approved = pallet_token_approvals::ERC1155ApprovalsForAll::<Runtime>::get(
 				Runtime::AccountId::from(operator),
 				(collection_id, Runtime::AccountId::from(handle.context().caller)),
 			)

--- a/evm-precompiles/erc20/src/lib.rs
+++ b/evm-precompiles/erc20/src/lib.rs
@@ -217,12 +217,10 @@ where
 		let spender: Runtime::AccountId = H160::from(spender).into();
 
 		// Fetch info.
-		let amount: U256 = pallet_token_approvals::Pallet::<Runtime>::erc20_approvals(
-			(&owner, &asset_id),
-			&spender,
-		)
-		.unwrap_or_default()
-		.into();
+		let amount: U256 =
+			pallet_token_approvals::ERC20Approvals::<Runtime>::get((&owner, &asset_id), &spender)
+				.unwrap_or_default()
+				.into();
 
 		// Build output.
 		Ok(succeed(EvmDataWriter::new().write(amount).build()))

--- a/evm-precompiles/erc721/src/lib.rs
+++ b/evm-precompiles/erc721/src/lib.rs
@@ -581,14 +581,12 @@ where
 
 		// Return either the approved account or zero address if no account is approved
 		handle.record_cost(RuntimeHelper::<Runtime>::db_read_gas_cost())?;
-		let approved_account: H160 =
-			match pallet_token_approvals::Pallet::<Runtime>::erc721_approvals((
-				collection_id,
-				serial_number,
-			)) {
-				Some(approved_account) => (approved_account).into(),
-				None => H160::default(),
-			};
+		let approved_account: H160 = match pallet_token_approvals::ERC721Approvals::<Runtime>::get(
+			(collection_id, serial_number),
+		) {
+			Some(approved_account) => (approved_account).into(),
+			None => H160::default(),
+		};
 
 		Ok(succeed(EvmDataWriter::new().write(Address::from(approved_account)).build()))
 	}
@@ -605,7 +603,7 @@ where
 		let operator: Runtime::AccountId = H160::from(operator).into();
 
 		handle.record_cost(RuntimeHelper::<Runtime>::db_read_gas_cost())?;
-		let is_approved = pallet_token_approvals::Pallet::<Runtime>::erc721_approvals_for_all(
+		let is_approved = pallet_token_approvals::ERC721ApprovalsForAll::<Runtime>::get(
 			owner,
 			(collection_id, operator),
 		)

--- a/pallet/dex/src/lib.rs
+++ b/pallet/dex/src/lib.rs
@@ -224,25 +224,20 @@ pub mod pallet {
 
 	/// FeeTo account where network fees are deposited
 	#[pallet::storage]
-	#[pallet::getter(fn fee_to)]
 	pub type FeeTo<T: Config> = StorageValue<_, Option<T::AccountId>, ValueQuery, DefaultFeeTo<T>>;
 
 	#[pallet::storage]
-	#[pallet::getter(fn lp_token_id)]
 	pub type TradingPairLPToken<T: Config> =
 		StorageMap<_, Twox64Concat, TradingPair, Option<AssetId>, ValueQuery>;
 
 	#[pallet::storage]
-	#[pallet::getter(fn liquidity_pool)]
 	pub type LiquidityPool<T: Config> =
 		StorageMap<_, Twox64Concat, TradingPair, (Balance, Balance), ValueQuery>;
 
 	#[pallet::storage]
-	#[pallet::getter(fn liquidity_pool_last_k)]
 	pub type LiquidityPoolLastK<T: Config> = StorageMap<_, Twox64Concat, AssetId, U256, ValueQuery>;
 
 	#[pallet::storage]
-	#[pallet::getter(fn trading_pair_statuses)]
 	pub type TradingPairStatuses<T: Config> =
 		StorageMap<_, Twox64Concat, TradingPair, TradingPairStatus, ValueQuery>;
 
@@ -466,11 +461,11 @@ pub mod pallet {
 			let trading_pair = TradingPair::new(token_a, token_b);
 
 			ensure!(
-				Self::lp_token_id(&trading_pair).is_some(),
+				TradingPairLPToken::<T>::get(&trading_pair).is_some(),
 				Error::<T>::LiquidityProviderTokenNotCreated
 			);
 
-			match Self::trading_pair_statuses(&trading_pair) {
+			match TradingPairStatuses::<T>::get(&trading_pair) {
 				TradingPairStatus::Enabled => return Err(Error::<T>::MustBeNotEnabled.into()),
 				// will enabled Disabled trading_pair
 				TradingPairStatus::NotEnabled => {
@@ -500,11 +495,11 @@ pub mod pallet {
 			let trading_pair = TradingPair::new(token_a, token_b);
 
 			ensure!(
-				Self::lp_token_id(&trading_pair).is_some(),
+				TradingPairLPToken::<T>::get(&trading_pair).is_some(),
 				Error::<T>::LiquidityProviderTokenNotCreated
 			);
 
-			match Self::trading_pair_statuses(&trading_pair) {
+			match TradingPairStatuses::<T>::get(&trading_pair) {
 				// will disable Enabled trading_pair
 				TradingPairStatus::Enabled => {
 					TradingPairStatuses::<T>::insert(trading_pair, TradingPairStatus::NotEnabled);
@@ -602,13 +597,13 @@ where
 
 		let trading_pair = TradingPair::new(token_a, token_b);
 		// create trading pair & lp token if non-existent
-		let lp_share_asset_id = match Self::lp_token_id(trading_pair) {
+		let lp_share_asset_id = match TradingPairLPToken::<T>::get(trading_pair) {
 			Some(lp_id) => lp_id,
 			None => Self::create_lp_token(&trading_pair)?,
 		};
 
 		ensure!(
-			matches!(Self::trading_pair_statuses(&trading_pair), TradingPairStatus::Enabled),
+			matches!(TradingPairStatuses::<T>::get(&trading_pair), TradingPairStatus::Enabled),
 			Error::<T>::MustBeEnabled,
 		);
 
@@ -769,7 +764,7 @@ where
 
 		let trading_pair = TradingPair::new(token_a, token_b);
 		let lp_share_asset_id =
-			Self::lp_token_id(trading_pair).ok_or(Error::<T>::InvalidAssetId)?;
+			TradingPairLPToken::<T>::get(trading_pair).ok_or(Error::<T>::InvalidAssetId)?;
 
 		ensure!(token_a != token_b, Error::<T>::IdenticalTokenAddress);
 
@@ -876,12 +871,12 @@ where
 		token_b: AssetId,
 	) -> sp_std::result::Result<AssetId, DispatchError> {
 		let trading_pair = TradingPair::new(token_a, token_b);
-		Self::lp_token_id(trading_pair).ok_or(Error::<T>::InvalidAssetId.into())
+		TradingPairLPToken::<T>::get(trading_pair).ok_or(Error::<T>::InvalidAssetId.into())
 	}
 
 	pub fn get_liquidity(token_a: AssetId, token_b: AssetId) -> (Balance, Balance) {
 		let trading_pair = TradingPair::new(token_a, token_b);
-		let (reserve_0, reserve_1) = Self::liquidity_pool(trading_pair);
+		let (reserve_0, reserve_1) = LiquidityPool::<T>::get(trading_pair);
 		if token_a == trading_pair.0 {
 			(reserve_0, reserve_1)
 		} else {
@@ -891,7 +886,7 @@ where
 
 	pub fn get_trading_pair_status(token_a: AssetId, token_b: AssetId) -> TradingPairStatus {
 		let trading_pair = TradingPair::new(token_a, token_b);
-		Self::trading_pair_statuses(trading_pair)
+		TradingPairStatuses::<T>::get(trading_pair)
 	}
 
 	/// Given an input amount of an asset and pair reserves, returns the maximum output amount of
@@ -965,7 +960,7 @@ where
 			// trading pair in path must be enabled
 			ensure!(
 				matches!(
-					Self::trading_pair_statuses(&TradingPair::new(path[i], path[i + 1])),
+					TradingPairStatuses::<T>::get(&TradingPair::new(path[i], path[i + 1])),
 					TradingPairStatus::Enabled
 				),
 				Error::<T>::MustBeEnabled
@@ -1006,7 +1001,7 @@ where
 			// trading pair in path must be enabled
 			ensure!(
 				matches!(
-					Self::trading_pair_statuses(&TradingPair::new(path[i - 1], path[i])),
+					TradingPairStatuses::<T>::get(&TradingPair::new(path[i - 1], path[i])),
 					TradingPairStatus::Enabled
 				),
 				Error::<T>::MustBeEnabled
@@ -1160,7 +1155,7 @@ where
 			if FeeTo::<T>::get().is_some() {
 				// get the lp shared asset id
 				let lp_share_asset_id =
-					Self::lp_token_id(trading_pair).ok_or(Error::<T>::InvalidAssetId)?;
+					TradingPairLPToken::<T>::get(trading_pair).ok_or(Error::<T>::InvalidAssetId)?;
 
 				// get the updated reserve values of the trading pair
 				let (reserve_a, reserve_b) = LiquidityPool::<T>::get(trading_pair);

--- a/pallet/dex/src/tests.rs
+++ b/pallet/dex/src/tests.rs
@@ -65,7 +65,7 @@ fn disable_trading_pair() {
 			TradingPair::new(usdc, weth),
 		)));
 		assert_eq!(
-			Dex::trading_pair_statuses(TradingPair::new(usdc, weth)),
+			TradingPairStatuses::<Test>::get(TradingPair::new(usdc, weth)),
 			TradingPairStatus::NotEnabled
 		);
 
@@ -101,7 +101,7 @@ fn reenable_trading_pair() {
 		);
 
 		// check that pair LP token does not exist
-		assert_eq!(Dex::lp_token_id(TradingPair::new(usdc, weth)).is_some(), false);
+		assert_eq!(TradingPairLPToken::<Test>::get(TradingPair::new(usdc, weth)).is_some(), false);
 
 		// manually create LP token and enable it
 		TradingPairLPToken::<Test>::insert(TradingPair::new(usdc, weth), Some(3));
@@ -125,7 +125,7 @@ fn reenable_trading_pair() {
 		// a disabled trading pair can be re-enabled
 		assert_ok!(Dex::reenable_trading_pair(RuntimeOrigin::root(), usdc, weth));
 		assert_eq!(
-			Dex::trading_pair_statuses(TradingPair::new(usdc, weth)),
+			TradingPairStatuses::<Test>::get(TradingPair::new(usdc, weth)),
 			TradingPairStatus::Enabled
 		);
 		System::assert_last_event(MockEvent::Dex(crate::Event::EnableTradingPair(
@@ -319,7 +319,7 @@ fn add_liquidity() {
 
 		// adding LP enables trading pair
 		assert_eq!(
-			Dex::trading_pair_statuses(TradingPair::new(usdc, weth)),
+			TradingPairStatuses::<Test>::get(TradingPair::new(usdc, weth)),
 			TradingPairStatus::Enabled
 		);
 
@@ -361,25 +361,25 @@ fn add_liquidity() {
 		)));
 
 		// the created lp token should be the 3rd created token (first 22bit) + 100 (last 10bits)
-		assert_eq!(Dex::lp_token_id(TradingPair::new(usdc, weth)).unwrap(), 3 << 10 | 100);
+		assert_eq!(TradingPairLPToken::<Test>::get(TradingPair::new(usdc, weth)).unwrap(), 3 << 10 | 100);
 
 		// check that the next asset id should be 4 (2 assets + 1 lp token)
 
 		// lp token is the same token independent of trading pair token ordering
 		assert_eq!(
-			Dex::lp_token_id(TradingPair::new(usdc, weth)),
-			Dex::lp_token_id(TradingPair::new(weth, usdc))
+			TradingPairLPToken::<Test>::get(TradingPair::new(usdc, weth)),
+			TradingPairLPToken::<Test>::get(TradingPair::new(weth, usdc))
 		);
 
 		// verify Alice now has LP tokens
 		assert_eq!(
-			AssetsExt::balance(Dex::lp_token_id(TradingPair::new(usdc, weth)).unwrap(), &alice),
+			AssetsExt::balance(TradingPairLPToken::<Test>::get(TradingPair::new(usdc, weth)).unwrap(), &alice),
 			999_999_999_999_999_000u128,
 		);
 
 		// verify Charlie now has LP tokens
 		assert_eq!(
-			AssetsExt::balance(Dex::lp_token_id(TradingPair::new(usdc, weth)).unwrap(), &charlie),
+			AssetsExt::balance(TradingPairLPToken::<Test>::get(TradingPair::new(usdc, weth)).unwrap(), &charlie),
 			1_000_000_000_000_000_000u128,
 		);
 
@@ -418,14 +418,14 @@ fn add_liquidity() {
 
 		// verify Bob now has LP tokens
 		assert_eq!(
-			AssetsExt::balance(Dex::lp_token_id(TradingPair::new(usdc, weth)).unwrap(), &bob),
+			AssetsExt::balance(TradingPairLPToken::<Test>::get(TradingPair::new(usdc, weth)).unwrap(), &bob),
 			to_eth(2),
 		);
 
 		// bob should have more LP tokens than Alice as Bob provisioned more liquidity
 		assert_eq!(
-			AssetsExt::balance(Dex::lp_token_id(TradingPair::new(usdc, weth)).unwrap(), &alice)
-				< AssetsExt::balance(Dex::lp_token_id(TradingPair::new(usdc, weth)).unwrap(), &bob),
+			AssetsExt::balance(TradingPairLPToken::<Test>::get(TradingPair::new(usdc, weth)).unwrap(), &alice)
+				< AssetsExt::balance(TradingPairLPToken::<Test>::get(TradingPair::new(usdc, weth)).unwrap(), &bob),
 			true
 		);
 
@@ -483,7 +483,7 @@ fn add_shared_liquidity() {
 		let trading_pair: TradingPair = TradingPair::new(usdc, weth);
 
 		// adding LP enables trading pair
-		assert_eq!(Dex::trading_pair_statuses(trading_pair), TradingPairStatus::Enabled);
+		assert_eq!(TradingPairStatuses::<Test>::get(trading_pair), TradingPairStatus::Enabled);
 
 		System::assert_last_event(MockEvent::Dex(crate::Event::AddLiquidity(
 			alice,
@@ -497,8 +497,8 @@ fn add_shared_liquidity() {
 
 		// lp token is the same token independent of trading pair token ordering
 		assert_eq!(
-			Dex::lp_token_id(TradingPair::new(usdc, weth)),
-			Dex::lp_token_id(TradingPair::new(weth, usdc))
+			TradingPairLPToken::<Test>::get(TradingPair::new(usdc, weth)),
+			TradingPairLPToken::<Test>::get(TradingPair::new(weth, usdc))
 		);
 
 		// mint tokens to new user
@@ -694,7 +694,7 @@ fn add_liquidity_issue_15() {
 			None,
 		));
 		assert_eq!(
-			AssetsExt::balance(Dex::lp_token_id(TradingPair::new(usdc, weth)).unwrap(), &alice),
+			AssetsExt::balance(TradingPairLPToken::<Test>::get(TradingPair::new(usdc, weth)).unwrap(), &alice),
 			1_999_999_999_999_999_000_u128,
 		);
 		assert_eq!(AssetsExt::balance(usdc, &alice), 8_000_000_000_000_000_000_u128);
@@ -729,7 +729,7 @@ fn remove_liquidity_simple() {
 			None,
 		));
 
-		let lp_token_id = Dex::lp_token_id(TradingPair::new(usdc, weth)).unwrap();
+		let lp_token_id = TradingPairLPToken::<Test>::get(TradingPair::new(usdc, weth)).unwrap();
 		assert_eq!(AssetsExt::balance(lp_token_id, &alice), 1_999_999_999_999_999_000u128);
 		assert_eq!(AssetsExt::balance(usdc, &alice), 0);
 		assert_eq!(AssetsExt::balance(weth, &alice), 0);
@@ -772,7 +772,7 @@ fn remove_liquidity_simple() {
 		)));
 
 		assert_eq!(
-			AssetsExt::balance(Dex::lp_token_id(TradingPair::new(usdc, weth)).unwrap(), &alice),
+			AssetsExt::balance(TradingPairLPToken::<Test>::get(TradingPair::new(usdc, weth)).unwrap(), &alice),
 			0,
 		);
 		assert_eq!(AssetsExt::balance(usdc, &bob), 1_999_999_999_999_999_000u128);
@@ -847,7 +847,7 @@ fn remove_liquidity_full() {
 			None,
 			None,
 		));
-		let lp_token_id = Dex::lp_token_id(TradingPair::new(usdc, weth)).unwrap(); // TODO remove
+		let lp_token_id = TradingPairLPToken::<Test>::get(TradingPair::new(usdc, weth)).unwrap(); // TODO remove
 		assert_eq!(AssetsExt::balance(lp_token_id, &alice), 1_999_999_999_999_999_000u128);
 		assert_eq!(AssetsExt::balance(usdc, &alice), 0);
 		assert_eq!(AssetsExt::balance(weth, &alice), 0);
@@ -918,7 +918,7 @@ fn remove_liquidity_full() {
 		)));
 
 		assert_eq!(
-			AssetsExt::balance(Dex::lp_token_id(TradingPair::new(usdc, weth)).unwrap(), &alice),
+			AssetsExt::balance(TradingPairLPToken::<Test>::get(TradingPair::new(usdc, weth)).unwrap(), &alice),
 			1,
 		);
 		assert_eq!(AssetsExt::balance(usdc, &alice), 1_999_999_999_999_998_999_u128);
@@ -945,7 +945,7 @@ fn remove_liquidity_full() {
 
 		// removing all liquidity should imply user has recieved all input tokens
 		assert_eq!(
-			AssetsExt::balance(Dex::lp_token_id(TradingPair::new(usdc, weth)).unwrap(), &alice),
+			AssetsExt::balance(TradingPairLPToken::<Test>::get(TradingPair::new(usdc, weth)).unwrap(), &alice),
 			0u128,
 		);
 		// do not get 100% tokens back as some lost due to minimum liquidity minting
@@ -1455,7 +1455,7 @@ fn multiple_swaps_with_multiple_lp() {
 			None,
 		));
 
-		let lp_usdc_weth = Dex::lp_token_id(TradingPair::new(usdc, weth)).unwrap();
+		let lp_usdc_weth = TradingPairLPToken::<Test>::get(TradingPair::new(usdc, weth)).unwrap();
 
 		// lp providers alice have lp tokens
 		assert_eq!(AssetsExt::balance(lp_usdc_weth, &alice), 17_320_508_075_688_771_935_u128);
@@ -1631,20 +1631,20 @@ fn set_fee_to() {
 
 		// check the default value of FeeTo
 		let fee_pot = DefaultFeeTo::<Test>::get().map(|v| v.into());
-		assert_eq!(Dex::fee_to(), fee_pot);
+		assert_eq!(FeeTo::<Test>::get(), fee_pot);
 
 		// normal user can not set FeeTo
 		assert_noop!(Dex::set_fee_to(RuntimeOrigin::signed(alice), Some(bob)), BadOrigin);
 
 		// change FeeTo with root user
 		assert_ok!(Dex::set_fee_to(RuntimeOrigin::root(), Some(bob)));
-		assert_eq!(Dex::fee_to().unwrap(), bob);
+		assert_eq!(FeeTo::<Test>::get().unwrap(), bob);
 
 		System::assert_last_event(MockEvent::Dex(crate::Event::FeeToSet(Some(bob))));
 
 		// disable FeeTo with root user
 		assert_ok!(Dex::set_fee_to(RuntimeOrigin::root(), None));
-		assert_eq!(Dex::fee_to().is_none(), true);
+		assert_eq!(FeeTo::<Test>::get().is_none(), true);
 
 		System::assert_last_event(MockEvent::Dex(crate::Event::FeeToSet(None)));
 	});
@@ -1679,8 +1679,8 @@ fn mint_fee() {
 
 		// get the lp token id
 		let trading_pair = TradingPair::new(usdc, weth);
-		let lp_token = Dex::lp_token_id(trading_pair).unwrap();
-		let (reserve_a, reserve_b) = Dex::liquidity_pool(trading_pair);
+		let lp_token = TradingPairLPToken::<Test>::get(trading_pair).unwrap();
+		let (reserve_a, reserve_b) = LiquidityPool::<Test>::get(trading_pair);
 
 		// set FeeTo to None
 		assert_ok!(Dex::set_fee_to(RuntimeOrigin::root(), None));
@@ -1755,11 +1755,11 @@ fn test_network_fee() {
 
 		// get the lp token id
 		let trading_pair = TradingPair::new(usdc, weth);
-		let lp_token = Dex::lp_token_id(trading_pair).unwrap();
+		let lp_token = TradingPairLPToken::<Test>::get(trading_pair).unwrap();
 
 		// the last k value should be updated as the product of the initial reserve values
 		let (reserve_0_init, reserve_1_init) = LiquidityPool::<Test>::get(trading_pair);
-		assert_eq!(Dex::liquidity_pool_last_k(lp_token), (reserve_0_init * reserve_1_init).into());
+		assert_eq!(LiquidityPoolLastK::<Test>::get(lp_token), (reserve_0_init * reserve_1_init).into());
 
 		// fee_pot doesn't have lp token balance before swaps happening
 		assert_eq!(AssetsExt::balance(lp_token, &fee_pot), 0);
@@ -1803,7 +1803,7 @@ fn test_network_fee() {
 
 		// the last k value should be updated after remove_liquidity is called
 		let (reserve_0_new, reserve_1_new) = LiquidityPool::<Test>::get(trading_pair);
-		assert_eq!(Dex::liquidity_pool_last_k(lp_token), (reserve_0_new * reserve_1_new).into());
+		assert_eq!(LiquidityPoolLastK::<Test>::get(lp_token), (reserve_0_new * reserve_1_new).into());
 	});
 }
 

--- a/pallet/dex/src/tests.rs
+++ b/pallet/dex/src/tests.rs
@@ -361,7 +361,10 @@ fn add_liquidity() {
 		)));
 
 		// the created lp token should be the 3rd created token (first 22bit) + 100 (last 10bits)
-		assert_eq!(TradingPairLPToken::<Test>::get(TradingPair::new(usdc, weth)).unwrap(), 3 << 10 | 100);
+		assert_eq!(
+			TradingPairLPToken::<Test>::get(TradingPair::new(usdc, weth)).unwrap(),
+			3 << 10 | 100
+		);
 
 		// check that the next asset id should be 4 (2 assets + 1 lp token)
 
@@ -373,13 +376,19 @@ fn add_liquidity() {
 
 		// verify Alice now has LP tokens
 		assert_eq!(
-			AssetsExt::balance(TradingPairLPToken::<Test>::get(TradingPair::new(usdc, weth)).unwrap(), &alice),
+			AssetsExt::balance(
+				TradingPairLPToken::<Test>::get(TradingPair::new(usdc, weth)).unwrap(),
+				&alice
+			),
 			999_999_999_999_999_000u128,
 		);
 
 		// verify Charlie now has LP tokens
 		assert_eq!(
-			AssetsExt::balance(TradingPairLPToken::<Test>::get(TradingPair::new(usdc, weth)).unwrap(), &charlie),
+			AssetsExt::balance(
+				TradingPairLPToken::<Test>::get(TradingPair::new(usdc, weth)).unwrap(),
+				&charlie
+			),
 			1_000_000_000_000_000_000u128,
 		);
 
@@ -418,14 +427,22 @@ fn add_liquidity() {
 
 		// verify Bob now has LP tokens
 		assert_eq!(
-			AssetsExt::balance(TradingPairLPToken::<Test>::get(TradingPair::new(usdc, weth)).unwrap(), &bob),
+			AssetsExt::balance(
+				TradingPairLPToken::<Test>::get(TradingPair::new(usdc, weth)).unwrap(),
+				&bob
+			),
 			to_eth(2),
 		);
 
 		// bob should have more LP tokens than Alice as Bob provisioned more liquidity
 		assert_eq!(
-			AssetsExt::balance(TradingPairLPToken::<Test>::get(TradingPair::new(usdc, weth)).unwrap(), &alice)
-				< AssetsExt::balance(TradingPairLPToken::<Test>::get(TradingPair::new(usdc, weth)).unwrap(), &bob),
+			AssetsExt::balance(
+				TradingPairLPToken::<Test>::get(TradingPair::new(usdc, weth)).unwrap(),
+				&alice
+			) < AssetsExt::balance(
+				TradingPairLPToken::<Test>::get(TradingPair::new(usdc, weth)).unwrap(),
+				&bob
+			),
 			true
 		);
 
@@ -694,7 +711,10 @@ fn add_liquidity_issue_15() {
 			None,
 		));
 		assert_eq!(
-			AssetsExt::balance(TradingPairLPToken::<Test>::get(TradingPair::new(usdc, weth)).unwrap(), &alice),
+			AssetsExt::balance(
+				TradingPairLPToken::<Test>::get(TradingPair::new(usdc, weth)).unwrap(),
+				&alice
+			),
 			1_999_999_999_999_999_000_u128,
 		);
 		assert_eq!(AssetsExt::balance(usdc, &alice), 8_000_000_000_000_000_000_u128);
@@ -772,7 +792,10 @@ fn remove_liquidity_simple() {
 		)));
 
 		assert_eq!(
-			AssetsExt::balance(TradingPairLPToken::<Test>::get(TradingPair::new(usdc, weth)).unwrap(), &alice),
+			AssetsExt::balance(
+				TradingPairLPToken::<Test>::get(TradingPair::new(usdc, weth)).unwrap(),
+				&alice
+			),
 			0,
 		);
 		assert_eq!(AssetsExt::balance(usdc, &bob), 1_999_999_999_999_999_000u128);
@@ -918,7 +941,10 @@ fn remove_liquidity_full() {
 		)));
 
 		assert_eq!(
-			AssetsExt::balance(TradingPairLPToken::<Test>::get(TradingPair::new(usdc, weth)).unwrap(), &alice),
+			AssetsExt::balance(
+				TradingPairLPToken::<Test>::get(TradingPair::new(usdc, weth)).unwrap(),
+				&alice
+			),
 			1,
 		);
 		assert_eq!(AssetsExt::balance(usdc, &alice), 1_999_999_999_999_998_999_u128);
@@ -945,7 +971,10 @@ fn remove_liquidity_full() {
 
 		// removing all liquidity should imply user has recieved all input tokens
 		assert_eq!(
-			AssetsExt::balance(TradingPairLPToken::<Test>::get(TradingPair::new(usdc, weth)).unwrap(), &alice),
+			AssetsExt::balance(
+				TradingPairLPToken::<Test>::get(TradingPair::new(usdc, weth)).unwrap(),
+				&alice
+			),
 			0u128,
 		);
 		// do not get 100% tokens back as some lost due to minimum liquidity minting
@@ -1759,7 +1788,10 @@ fn test_network_fee() {
 
 		// the last k value should be updated as the product of the initial reserve values
 		let (reserve_0_init, reserve_1_init) = LiquidityPool::<Test>::get(trading_pair);
-		assert_eq!(LiquidityPoolLastK::<Test>::get(lp_token), (reserve_0_init * reserve_1_init).into());
+		assert_eq!(
+			LiquidityPoolLastK::<Test>::get(lp_token),
+			(reserve_0_init * reserve_1_init).into()
+		);
 
 		// fee_pot doesn't have lp token balance before swaps happening
 		assert_eq!(AssetsExt::balance(lp_token, &fee_pot), 0);
@@ -1803,7 +1835,10 @@ fn test_network_fee() {
 
 		// the last k value should be updated after remove_liquidity is called
 		let (reserve_0_new, reserve_1_new) = LiquidityPool::<Test>::get(trading_pair);
-		assert_eq!(LiquidityPoolLastK::<Test>::get(lp_token), (reserve_0_new * reserve_1_new).into());
+		assert_eq!(
+			LiquidityPoolLastK::<Test>::get(lp_token),
+			(reserve_0_new * reserve_1_new).into()
+		);
 	});
 }
 

--- a/pallet/echo/src/lib.rs
+++ b/pallet/echo/src/lib.rs
@@ -73,7 +73,6 @@ pub mod pallet {
 
 	/// The next available offer_id
 	#[pallet::storage]
-	#[pallet::getter(fn next_session_id)]
 	pub type NextSessionId<T> = StorageValue<_, u64, ValueQuery>;
 
 	#[pallet::event]
@@ -108,7 +107,7 @@ pub mod pallet {
 			let source: H160 = ensure_signed(origin)?.into();
 
 			// Get session id and ensure within u64 bounds
-			let session_id = Self::next_session_id();
+			let session_id = NextSessionId::<T>::get();
 			ensure!(session_id.checked_add(u64::one()).is_some(), Error::<T>::NoAvailableIds);
 
 			// Encode the message, the first value as 0 states that the event was sent from this

--- a/pallet/echo/src/tests.rs
+++ b/pallet/echo/src/tests.rs
@@ -24,12 +24,12 @@ fn ping_works_from_runtime() {
 	TestExt::<Test>::default().build().execute_with(|| {
 		let caller = H160::from_low_u64_be(123);
 		let destination = <Test as Config>::PalletId::get().into_account_truncating();
-		let next_session_id = Echo::next_session_id();
+		let next_session_id = NextSessionId::<Test>::get();
 
 		assert_ok!(Echo::ping(Some(AccountId::from(caller)).into(), destination));
 
 		// Check storage updated
-		assert_eq!(Echo::next_session_id(), next_session_id + 1);
+		assert_eq!(NextSessionId::<Test>::get(), next_session_id + 1);
 
 		// Check PingSent event thrown
 		System::assert_has_event(
@@ -64,7 +64,7 @@ fn ping_works_from_ethereum() {
 	TestExt::<Test>::default().build().execute_with(|| {
 		let caller = H160::from_low_u64_be(123);
 		let destination = <Test as Config>::PalletId::get().into_account_truncating();
-		let next_session_id = Echo::next_session_id();
+		let next_session_id = NextSessionId::<Test>::get();
 
 		let data = ethabi::encode(&[
 			Token::Uint(PONG.into()),

--- a/pallet/evm-chain-id/src/benchmarking.rs
+++ b/pallet/evm-chain-id/src/benchmarking.rs
@@ -17,6 +17,7 @@
 
 use super::*;
 
+#[allow(unused_imports)]
 use crate::Pallet as EVMChainId;
 
 use frame_benchmarking::{benchmarks, impl_benchmark_test_suite};
@@ -28,7 +29,7 @@ benchmarks! {
 		assert_eq!(ChainId::<T>::get(), T::DefaultChainId::get());
 	}: _(RawOrigin::Root, 1234)
 	verify {
-		assert_eq!(EVMChainId::<T>::chain_id(), 1234);
+		assert_eq!(ChainId::<T>::get(), 1234);
 	}
 
 }

--- a/pallet/evm-chain-id/src/lib.rs
+++ b/pallet/evm-chain-id/src/lib.rs
@@ -63,7 +63,7 @@ pub mod pallet {
 
 	impl<T: Config> Get<u64> for Pallet<T> {
 		fn get() -> u64 {
-			Self::chain_id()
+			ChainId::<T>::get()
 		}
 	}
 
@@ -74,7 +74,6 @@ pub mod pallet {
 
 	/// The EVM chain ID.
 	#[pallet::storage]
-	#[pallet::getter(fn chain_id)]
 	pub type ChainId<T> = StorageValue<_, u64, ValueQuery, DefaultChainId<T>>;
 
 	#[pallet::event]

--- a/pallet/evm-chain-id/src/tests.rs
+++ b/pallet/evm-chain-id/src/tests.rs
@@ -14,8 +14,8 @@
 // You may obtain a copy of the License at the root of this project source code
 
 #![cfg(test)]
-use crate::ChainId;
 use crate::mock::{EVMChainId, RuntimeEvent, RuntimeOrigin, System, Test, TestExt};
+use crate::ChainId;
 use seed_pallet_common::test_prelude::*;
 
 #[test]

--- a/pallet/evm-chain-id/src/tests.rs
+++ b/pallet/evm-chain-id/src/tests.rs
@@ -14,13 +14,14 @@
 // You may obtain a copy of the License at the root of this project source code
 
 #![cfg(test)]
-use crate::mock::{EVMChainId, RuntimeEvent, RuntimeOrigin, System, TestExt};
+use crate::ChainId;
+use crate::mock::{EVMChainId, RuntimeEvent, RuntimeOrigin, System, Test, TestExt};
 use seed_pallet_common::test_prelude::*;
 
 #[test]
 fn default_chain_id() {
 	TestExt::default().build().execute_with(|| {
-		let chain_id = EVMChainId::chain_id();
+		let chain_id = ChainId::<Test>::get();
 		assert_eq!(chain_id, 7672);
 	});
 }
@@ -30,11 +31,11 @@ fn update_chain_id() {
 	TestExt::default().build().execute_with(|| {
 		// normal user cannot update chain id
 		assert_noop!(EVMChainId::set_chain_id(RuntimeOrigin::signed(alice()), 1234), BadOrigin);
-		assert_eq!(EVMChainId::chain_id(), 7672); // chain id is not updated
+		assert_eq!(ChainId::<Test>::get(), 7672); // chain id is not updated
 
 		// root user can update chain id
 		assert_ok!(EVMChainId::set_chain_id(RuntimeOrigin::root().into(), 1234));
-		assert_eq!(EVMChainId::chain_id(), 1234); // chain id is updated
+		assert_eq!(ChainId::<Test>::get(), 1234); // chain id is updated
 
 		System::assert_last_event(RuntimeEvent::EVMChainId(crate::Event::ChainIdSet(1234)));
 	});

--- a/pallet/marketplace/src/impls.rs
+++ b/pallet/marketplace/src/impls.rs
@@ -32,7 +32,7 @@ impl<T: Config> Pallet<T> {
 			Error::<T>::RoyaltiesInvalid
 		);
 		let marketplace_account = marketplace_account.unwrap_or(who);
-		let marketplace_id = Self::next_marketplace_id();
+		let marketplace_id = NextMarketplaceId::<T>::get();
 		let marketplace = Marketplace { account: marketplace_account.clone(), entitlement };
 		let next_marketplace_id = <NextMarketplaceId<T>>::get();
 		ensure!(next_marketplace_id.checked_add(One::one()).is_some(), Error::<T>::NoAvailableIds);
@@ -61,7 +61,7 @@ impl<T: Config> Pallet<T> {
 		// Validate tokens
 		tokens.validate()?;
 		let royalties_schedule = Self::calculate_bundle_royalties(tokens.clone(), marketplace_id)?;
-		let listing_id = Self::next_listing_id();
+		let listing_id = NextListingId::<T>::get();
 
 		tokens.lock_tokens(&who, listing_id)?;
 
@@ -126,7 +126,7 @@ impl<T: Config> Pallet<T> {
 
 	// /// Returns the offer detail of a specified offer_id
 	pub fn get_offer_detail(offer_id: OfferId) -> Result<SimpleOffer<T::AccountId>, DispatchError> {
-		let Some(OfferType::Simple(offer)) = Self::offers(offer_id) else {
+		let Some(OfferType::Simple(offer)) = Offers::<T>::get(offer_id) else {
 			return Err(Error::<T>::InvalidOffer.into());
 		};
 		Ok(offer)
@@ -182,7 +182,7 @@ impl<T: Config> Pallet<T> {
 		// Validate tokens and get collection_id
 		tokens.validate()?;
 		let royalties_schedule = Self::calculate_bundle_royalties(tokens.clone(), marketplace_id)?;
-		let listing_id = Self::next_listing_id();
+		let listing_id = NextListingId::<T>::get();
 		ensure!(listing_id.checked_add(One::one()).is_some(), Error::<T>::NoAvailableIds);
 
 		tokens.lock_tokens(&who, listing_id)?;
@@ -220,7 +220,7 @@ impl<T: Config> Pallet<T> {
 			_ => return Err(Error::<T>::NotForAuction.into()),
 		};
 
-		if let Some(current_bid) = Self::listing_winning_bid(listing_id) {
+		if let Some(current_bid) = ListingWinningBid::<T>::get(listing_id) {
 			ensure!(amount > current_bid.1, Error::<T>::BidTooLow);
 		} else {
 			// first bid
@@ -283,7 +283,7 @@ impl<T: Config> Pallet<T> {
 			},
 			Listing::<T>::Auction(auction) => {
 				ensure!(auction.seller == who, Error::<T>::NotSeller);
-				ensure!(Self::listing_winning_bid(listing_id).is_none(), Error::<T>::TokenLocked);
+				ensure!(ListingWinningBid::<T>::get(listing_id).is_none(), Error::<T>::TokenLocked);
 				auction.tokens.unlock_tokens(&who)?;
 
 				Self::deposit_event(Event::<T>::AuctionClose {
@@ -311,7 +311,7 @@ impl<T: Config> Pallet<T> {
 		let token_owner = T::NFTExt::get_token_owner(&token_id);
 		ensure!(token_owner.is_some(), Error::<T>::NoToken);
 		ensure!(token_owner != Some(who), Error::<T>::IsTokenOwner);
-		let offer_id = Self::next_offer_id();
+		let offer_id = NextOfferId::<T>::get();
 		ensure!(offer_id.checked_add(One::one()).is_some(), Error::<T>::NoAvailableIds);
 
 		// ensure the token_id is not currently in an auction
@@ -347,7 +347,7 @@ impl<T: Config> Pallet<T> {
 	}
 
 	pub fn do_cancel_offer(who: T::AccountId, offer_id: OfferId) -> DispatchResult {
-		let Some(OfferType::Simple(offer)) = Self::offers(offer_id) else {
+		let Some(OfferType::Simple(offer)) = Offers::<T>::get(offer_id) else {
 			return Err(Error::<T>::InvalidOffer.into());
 		};
 		ensure!(offer.buyer == who, Error::<T>::NotBuyer);
@@ -362,7 +362,7 @@ impl<T: Config> Pallet<T> {
 	}
 
 	pub fn do_accept_offer(who: T::AccountId, offer_id: OfferId) -> DispatchResult {
-		let Some(OfferType::Simple(offer)) = Self::offers(offer_id) else {
+		let Some(OfferType::Simple(offer)) = Offers::<T>::get(offer_id) else {
 			return Err(Error::<T>::InvalidOffer.into());
 		};
 

--- a/pallet/marketplace/src/lib.rs
+++ b/pallet/marketplace/src/lib.rs
@@ -125,12 +125,10 @@ pub mod pallet {
 
 	/// The next available marketplace id
 	#[pallet::storage]
-	#[pallet::getter(fn next_marketplace_id)]
 	pub type NextMarketplaceId<T> = StorageValue<_, MarketplaceId, ValueQuery>;
 
 	/// Map from marketplace account_id to royalties schedule
 	#[pallet::storage]
-	#[pallet::getter(fn registered_marketplaces)]
 	pub type RegisteredMarketplaces<T: Config> =
 		StorageMap<_, Twox64Concat, MarketplaceId, Marketplace<T::AccountId>>;
 
@@ -140,42 +138,35 @@ pub mod pallet {
 
 	/// The next available listing Id
 	#[pallet::storage]
-	#[pallet::getter(fn next_listing_id)]
 	pub type NextListingId<T> = StorageValue<_, ListingId, ValueQuery>;
 
 	/// Map from collection to any open listings
 	#[pallet::storage]
-	#[pallet::getter(fn open_collection_listings)]
 	pub type OpenCollectionListings<T> =
 		StorageDoubleMap<_, Twox64Concat, CollectionUuid, Twox64Concat, ListingId, bool>;
 
 	/// Winning bids on open listings.
 	#[pallet::storage]
-	#[pallet::getter(fn listing_winning_bid)]
 	pub type ListingWinningBid<T: Config> =
 		StorageMap<_, Twox64Concat, ListingId, (T::AccountId, Balance)>;
 
 	/// Block numbers where listings will close. Value is `true` if at block number `listing_id` is
 	/// scheduled to close.
 	#[pallet::storage]
-	#[pallet::getter(fn listing_end_schedule)]
 	pub type ListingEndSchedule<T: Config> =
 		StorageDoubleMap<_, Twox64Concat, BlockNumberFor<T>, Twox64Concat, ListingId, bool>;
 
 	/// Map from offer_id to the information related to the offer
 	#[pallet::storage]
-	#[pallet::getter(fn offers)]
 	pub type Offers<T: Config> = StorageMap<_, Twox64Concat, OfferId, OfferType<T::AccountId>>;
 
 	/// Maps from token_id to a vector of offer_ids on that token
 	#[pallet::storage]
-	#[pallet::getter(fn token_offers)]
 	pub type TokenOffers<T: Config> =
 		StorageMap<_, Twox64Concat, TokenId, BoundedVec<OfferId, T::MaxOffers>>;
 
 	/// The next available offer_id
 	#[pallet::storage]
-	#[pallet::getter(fn next_offer_id)]
 	pub type NextOfferId<T> = StorageValue<_, OfferId, ValueQuery>;
 
 	/// The pallet id for the tx fee pot

--- a/pallet/token-approvals/src/lib.rs
+++ b/pallet/token-approvals/src/lib.rs
@@ -58,12 +58,10 @@ pub mod pallet {
 
 	// Account with transfer approval for a single NFT
 	#[pallet::storage]
-	#[pallet::getter(fn erc721_approvals)]
 	pub type ERC721Approvals<T: Config> = StorageMap<_, Twox64Concat, TokenId, T::AccountId>;
 
 	// Accounts with transfer approval for an NFT collection of another account
 	#[pallet::storage]
-	#[pallet::getter(fn erc721_approvals_for_all)]
 	pub type ERC721ApprovalsForAll<T: Config> = StorageDoubleMap<
 		_,
 		Twox64Concat,
@@ -75,7 +73,6 @@ pub mod pallet {
 
 	// Mapping from account/ asset_id to an approved balance of another account
 	#[pallet::storage]
-	#[pallet::getter(fn erc20_approvals)]
 	pub type ERC20Approvals<T: Config> = StorageDoubleMap<
 		_,
 		Twox64Concat,
@@ -87,7 +84,6 @@ pub mod pallet {
 
 	// Accounts with transfer approval for an SFT collection of another account
 	#[pallet::storage]
-	#[pallet::getter(fn erc1155_approvals_for_all)]
 	pub type ERC1155ApprovalsForAll<T: Config> = StorageDoubleMap<
 		_,
 		Twox64Concat,
@@ -140,7 +136,7 @@ pub mod pallet {
 			};
 
 			let is_approved_for_all =
-				Self::erc721_approvals_for_all(&token_owner, (token_id.0, caller.clone()))
+				ERC721ApprovalsForAll::<T>::get(&token_owner, (token_id.0, caller.clone()))
 					.unwrap_or_default();
 			ensure!(
 				token_owner == caller || is_approved_for_all,
@@ -194,7 +190,7 @@ pub mod pallet {
 			amount: Balance,
 		) -> DispatchResult {
 			let _ = ensure_none(origin)?;
-			let new_approved_amount = Self::erc20_approvals((&caller, asset_id), &spender)
+			let new_approved_amount = ERC20Approvals::<T>::get((&caller, asset_id), &spender)
 				.ok_or(Error::<T>::CallerNotApproved)?
 				.checked_sub(amount)
 				.ok_or(Error::<T>::ApprovedAmountTooLow)?;
@@ -277,7 +273,7 @@ impl<T: Config> Pallet<T> {
 
 		// Check approvalForAll
 		if let Some(owner) = token_owner {
-			if Self::erc721_approvals_for_all(owner, (token_id.0, spender.clone()))
+			if ERC721ApprovalsForAll::<T>::get(owner, (token_id.0, spender.clone()))
 				.unwrap_or_default()
 			{
 				return true;
@@ -285,7 +281,7 @@ impl<T: Config> Pallet<T> {
 		}
 
 		// Lastly, Check token approval
-		Some(spender) == Self::erc721_approvals(token_id)
+		Some(spender) == ERC721Approvals::<T>::get(token_id)
 	}
 }
 

--- a/pallet/token-approvals/src/tests.rs
+++ b/pallet/token-approvals/src/tests.rs
@@ -14,8 +14,8 @@
 // You may obtain a copy of the License at the root of this project source code
 
 use super::*;
-use crate::{ERC1155ApprovalsForAll, ERC20Approvals, ERC721Approvals, ERC721ApprovalsForAll};
 use crate::mock::{Nft, Test, TokenApprovals};
+use crate::{ERC1155ApprovalsForAll, ERC20Approvals, ERC721Approvals, ERC721ApprovalsForAll};
 use seed_pallet_common::test_prelude::*;
 use seed_primitives::OriginChain;
 
@@ -334,9 +334,7 @@ fn set_erc721_approval_for_all() {
 			collection_id,
 			true
 		));
-		assert!(
-			ERC721ApprovalsForAll::<Test>::get(caller, (collection_id, operator)).unwrap()
-		);
+		assert!(ERC721ApprovalsForAll::<Test>::get(caller, (collection_id, operator)).unwrap());
 
 		// Remove approval
 		assert_ok!(TokenApprovals::erc721_approval_for_all(
@@ -346,9 +344,7 @@ fn set_erc721_approval_for_all() {
 			collection_id,
 			false
 		));
-		assert!(
-			ERC721ApprovalsForAll::<Test>::get(caller, (collection_id, operator)).is_none()
-		);
+		assert!(ERC721ApprovalsForAll::<Test>::get(caller, (collection_id, operator)).is_none());
 	});
 }
 
@@ -385,15 +381,9 @@ fn set_erc721_approval_for_all_multiple_approvals() {
 		));
 
 		// Check storage
-		assert!(
-			ERC721ApprovalsForAll::<Test>::get(caller, (collection_id, operator_1)).unwrap()
-		);
-		assert!(
-			ERC721ApprovalsForAll::<Test>::get(caller, (collection_id, operator_2)).unwrap()
-		);
-		assert!(
-			ERC721ApprovalsForAll::<Test>::get(caller, (collection_id, operator_3)).unwrap()
-		);
+		assert!(ERC721ApprovalsForAll::<Test>::get(caller, (collection_id, operator_1)).unwrap());
+		assert!(ERC721ApprovalsForAll::<Test>::get(caller, (collection_id, operator_2)).unwrap());
+		assert!(ERC721ApprovalsForAll::<Test>::get(caller, (collection_id, operator_3)).unwrap());
 	});
 }
 
@@ -468,9 +458,7 @@ fn set_erc1155_approval_for_all() {
 			collection_id,
 			true
 		));
-		assert!(
-			ERC1155ApprovalsForAll::<Test>::get(caller, (collection_id, operator)).unwrap()
-		);
+		assert!(ERC1155ApprovalsForAll::<Test>::get(caller, (collection_id, operator)).unwrap());
 
 		// Remove approval
 		assert_ok!(TokenApprovals::erc1155_approval_for_all(
@@ -480,9 +468,7 @@ fn set_erc1155_approval_for_all() {
 			collection_id,
 			false
 		));
-		assert!(
-			ERC1155ApprovalsForAll::<Test>::get(caller, (collection_id, operator)).is_none()
-		);
+		assert!(ERC1155ApprovalsForAll::<Test>::get(caller, (collection_id, operator)).is_none());
 	});
 }
 
@@ -519,15 +505,9 @@ fn set_erc1155_approval_for_all_multiple_approvals() {
 		));
 
 		// Check storage
-		assert!(
-			ERC1155ApprovalsForAll::<Test>::get(caller, (collection_id, operator_1)).unwrap()
-		);
-		assert!(
-			ERC1155ApprovalsForAll::<Test>::get(caller, (collection_id, operator_2)).unwrap()
-		);
-		assert!(
-			ERC1155ApprovalsForAll::<Test>::get(caller, (collection_id, operator_3)).unwrap()
-		);
+		assert!(ERC1155ApprovalsForAll::<Test>::get(caller, (collection_id, operator_1)).unwrap());
+		assert!(ERC1155ApprovalsForAll::<Test>::get(caller, (collection_id, operator_2)).unwrap());
+		assert!(ERC1155ApprovalsForAll::<Test>::get(caller, (collection_id, operator_3)).unwrap());
 	});
 }
 

--- a/pallet/token-approvals/src/tests.rs
+++ b/pallet/token-approvals/src/tests.rs
@@ -14,6 +14,7 @@
 // You may obtain a copy of the License at the root of this project source code
 
 use super::*;
+use crate::{ERC1155ApprovalsForAll, ERC20Approvals, ERC721Approvals, ERC721ApprovalsForAll};
 use crate::mock::{Nft, Test, TokenApprovals};
 use seed_pallet_common::test_prelude::*;
 use seed_primitives::OriginChain;
@@ -72,7 +73,7 @@ fn set_erc721_approval() {
 		let operator = create_account(12);
 
 		assert_ok!(TokenApprovals::erc721_approval(None.into(), caller, operator, token_id));
-		assert_eq!(TokenApprovals::erc721_approvals(token_id).unwrap(), operator);
+		assert_eq!(ERC721Approvals::<Test>::get(token_id).unwrap(), operator);
 	});
 }
 
@@ -95,7 +96,7 @@ fn set_erc721_approval_approved_for_all() {
 
 		// Caller is not token owner, but they are approved for all so this passes
 		assert_ok!(TokenApprovals::erc721_approval(None.into(), caller, operator, token_id));
-		assert_eq!(TokenApprovals::erc721_approvals(token_id).unwrap(), operator);
+		assert_eq!(ERC721Approvals::<Test>::get(token_id).unwrap(), operator);
 		// 000_001_500_000_000_000
 	});
 }
@@ -136,7 +137,7 @@ fn erc721_approval_removed_on_transfer() {
 		let operator = create_account(11);
 
 		assert_ok!(TokenApprovals::erc721_approval(None.into(), caller, operator, token_id));
-		assert_eq!(TokenApprovals::erc721_approvals(token_id).unwrap(), operator);
+		assert_eq!(ERC721Approvals::<Test>::get(token_id).unwrap(), operator);
 		TokenApprovals::on_nft_transfer(&token_id);
 		assert!(!ERC721Approvals::<Test>::contains_key(token_id));
 	});
@@ -197,7 +198,7 @@ fn set_erc20_approval() {
 		let amount: Balance = 10;
 
 		assert_ok!(TokenApprovals::erc20_approval(None.into(), caller, spender, asset_id, amount));
-		assert_eq!(TokenApprovals::erc20_approvals((caller, asset_id), spender).unwrap(), amount);
+		assert_eq!(ERC20Approvals::<Test>::get((caller, asset_id), spender).unwrap(), amount);
 	});
 }
 
@@ -225,7 +226,7 @@ fn update_erc20_approval_full_amount() {
 		let amount: Balance = 10;
 
 		assert_ok!(TokenApprovals::erc20_approval(None.into(), caller, spender, asset_id, amount));
-		assert_eq!(TokenApprovals::erc20_approvals((caller, asset_id), spender).unwrap(), amount);
+		assert_eq!(ERC20Approvals::<Test>::get((caller, asset_id), spender).unwrap(), amount);
 
 		// Remove approval
 		assert_ok!(TokenApprovals::erc20_update_approval(
@@ -248,7 +249,7 @@ fn update_erc20_approval_some_amount() {
 		let amount: Balance = 10;
 
 		assert_ok!(TokenApprovals::erc20_approval(None.into(), caller, spender, asset_id, amount));
-		assert_eq!(TokenApprovals::erc20_approvals((caller, asset_id), spender).unwrap(), amount);
+		assert_eq!(ERC20Approvals::<Test>::get((caller, asset_id), spender).unwrap(), amount);
 
 		let removal_amount: Balance = 9;
 		// Remove approval
@@ -260,7 +261,7 @@ fn update_erc20_approval_some_amount() {
 			removal_amount
 		));
 		assert_eq!(
-			TokenApprovals::erc20_approvals((caller, asset_id), spender).unwrap(),
+			ERC20Approvals::<Test>::get((caller, asset_id), spender).unwrap(),
 			amount - removal_amount
 		);
 	});
@@ -275,7 +276,7 @@ fn update_erc20_approval_amount_too_high_should_fail() {
 		let amount: Balance = 10;
 
 		assert_ok!(TokenApprovals::erc20_approval(None.into(), caller, spender, asset_id, amount));
-		assert_eq!(TokenApprovals::erc20_approvals((caller, asset_id), spender).unwrap(), amount);
+		assert_eq!(ERC20Approvals::<Test>::get((caller, asset_id), spender).unwrap(), amount);
 
 		let removal_amount: Balance = 11;
 		// Attempt to remove approval
@@ -301,7 +302,7 @@ fn update_erc20_approval_not_approved_should_fail() {
 		let amount: Balance = 10;
 
 		assert_ok!(TokenApprovals::erc20_approval(None.into(), caller, spender, asset_id, amount));
-		assert_eq!(TokenApprovals::erc20_approvals((caller, asset_id), spender).unwrap(), amount);
+		assert_eq!(ERC20Approvals::<Test>::get((caller, asset_id), spender).unwrap(), amount);
 
 		let malicious_spender = create_account(13);
 		// Attempt to remove approval
@@ -334,7 +335,7 @@ fn set_erc721_approval_for_all() {
 			true
 		));
 		assert!(
-			TokenApprovals::erc721_approvals_for_all(caller, (collection_id, operator)).unwrap()
+			ERC721ApprovalsForAll::<Test>::get(caller, (collection_id, operator)).unwrap()
 		);
 
 		// Remove approval
@@ -346,7 +347,7 @@ fn set_erc721_approval_for_all() {
 			false
 		));
 		assert!(
-			TokenApprovals::erc721_approvals_for_all(caller, (collection_id, operator)).is_none()
+			ERC721ApprovalsForAll::<Test>::get(caller, (collection_id, operator)).is_none()
 		);
 	});
 }
@@ -385,13 +386,13 @@ fn set_erc721_approval_for_all_multiple_approvals() {
 
 		// Check storage
 		assert!(
-			TokenApprovals::erc721_approvals_for_all(caller, (collection_id, operator_1)).unwrap()
+			ERC721ApprovalsForAll::<Test>::get(caller, (collection_id, operator_1)).unwrap()
 		);
 		assert!(
-			TokenApprovals::erc721_approvals_for_all(caller, (collection_id, operator_2)).unwrap()
+			ERC721ApprovalsForAll::<Test>::get(caller, (collection_id, operator_2)).unwrap()
 		);
 		assert!(
-			TokenApprovals::erc721_approvals_for_all(caller, (collection_id, operator_3)).unwrap()
+			ERC721ApprovalsForAll::<Test>::get(caller, (collection_id, operator_3)).unwrap()
 		);
 	});
 }
@@ -468,7 +469,7 @@ fn set_erc1155_approval_for_all() {
 			true
 		));
 		assert!(
-			TokenApprovals::erc1155_approvals_for_all(caller, (collection_id, operator)).unwrap()
+			ERC1155ApprovalsForAll::<Test>::get(caller, (collection_id, operator)).unwrap()
 		);
 
 		// Remove approval
@@ -480,7 +481,7 @@ fn set_erc1155_approval_for_all() {
 			false
 		));
 		assert!(
-			TokenApprovals::erc1155_approvals_for_all(caller, (collection_id, operator)).is_none()
+			ERC1155ApprovalsForAll::<Test>::get(caller, (collection_id, operator)).is_none()
 		);
 	});
 }
@@ -519,13 +520,13 @@ fn set_erc1155_approval_for_all_multiple_approvals() {
 
 		// Check storage
 		assert!(
-			TokenApprovals::erc1155_approvals_for_all(caller, (collection_id, operator_1)).unwrap()
+			ERC1155ApprovalsForAll::<Test>::get(caller, (collection_id, operator_1)).unwrap()
 		);
 		assert!(
-			TokenApprovals::erc1155_approvals_for_all(caller, (collection_id, operator_2)).unwrap()
+			ERC1155ApprovalsForAll::<Test>::get(caller, (collection_id, operator_2)).unwrap()
 		);
 		assert!(
-			TokenApprovals::erc1155_approvals_for_all(caller, (collection_id, operator_3)).unwrap()
+			ERC1155ApprovalsForAll::<Test>::get(caller, (collection_id, operator_3)).unwrap()
 		);
 	});
 }

--- a/pallet/tx-fee-pot/src/lib.rs
+++ b/pallet/tx-fee-pot/src/lib.rs
@@ -61,7 +61,6 @@ pub mod pallet {
 
 	/// Accrued transaction fees in the current staking Era
 	#[pallet::storage]
-	#[pallet::getter(fn era_tx_fees)]
 	pub type EraTxFees<T> = StorageValue<_, Balance, ValueQuery>;
 }
 
@@ -76,7 +75,7 @@ impl<T: Config> Pallet<T> {
 	}
 	/// Get the tx fee pot balance (current era)
 	pub fn era_pot_balance() -> Balance {
-		Self::era_tx_fees()
+		EraTxFees::<T>::get()
 	}
 	/// Get the tx fee pot balance (all eras - any claimed amounts)
 	pub fn total_pot_balance() -> Balance {

--- a/pallet/xrpl-bridge/src/lib.rs
+++ b/pallet/xrpl-bridge/src/lib.rs
@@ -406,7 +406,6 @@ pub mod pallet {
 		0_u32
 	}
 	#[pallet::storage]
-	#[pallet::getter(fn door_ticket_sequence)]
 	/// The current ticket sequence of the XRPL door accounts
 	pub type DoorTicketSequence<T: Config> = StorageMap<
 		_,
@@ -418,19 +417,16 @@ pub mod pallet {
 	>;
 
 	#[pallet::storage]
-	#[pallet::getter(fn door_ticket_sequence_params)]
 	/// The Ticket sequence params of the XRPL door accounts for the current allocation
 	pub type DoorTicketSequenceParams<T: Config> =
 		StorageMap<_, Twox64Concat, XRPLDoorAccount, XrplTicketSequenceParams, ValueQuery>;
 
 	#[pallet::storage]
-	#[pallet::getter(fn door_ticket_sequence_params_next)]
 	/// The Ticket sequence params of the XRPL door accounts for the next allocation
 	pub type DoorTicketSequenceParamsNext<T: Config> =
 		StorageMap<_, Twox64Concat, XRPLDoorAccount, XrplTicketSequenceParams, ValueQuery>;
 
 	#[pallet::storage]
-	#[pallet::getter(fn ticket_sequence_threshold_reached_emitted)]
 	/// Keeps track whether the TicketSequenceThresholdReached event is emitted for XRPL door accounts
 	pub type TicketSequenceThresholdReachedEmitted<T: Config> =
 		StorageMap<_, Twox64Concat, XRPLDoorAccount, bool, ValueQuery>;
@@ -676,8 +672,8 @@ pub mod pallet {
 			let active_relayer = <Relayer<T>>::get(&relayer).unwrap_or(false);
 			ensure!(active_relayer, Error::<T>::NotPermitted);
 
-			let current_ticket_sequence = Self::door_ticket_sequence(door_account);
-			let current_params = Self::door_ticket_sequence_params(door_account);
+			let current_ticket_sequence = DoorTicketSequence::<T>::get(door_account);
+			let current_params = DoorTicketSequenceParams::<T>::get(door_account);
 
 			if start_ticket_sequence < current_ticket_sequence
 				|| start_ticket_sequence < current_params.start_sequence
@@ -711,8 +707,8 @@ pub mod pallet {
 			ticket_bucket_size: u32,
 		) -> DispatchResult {
 			ensure_root(origin)?; // only the root will be able to do it
-			let current_ticket_sequence = Self::door_ticket_sequence(door_account);
-			let current_params = Self::door_ticket_sequence_params(door_account);
+			let current_ticket_sequence = DoorTicketSequence::<T>::get(door_account);
+			let current_params = DoorTicketSequenceParams::<T>::get(door_account);
 
 			if ticket_sequence < current_ticket_sequence
 				|| start_ticket_sequence < current_params.start_sequence
@@ -1697,8 +1693,8 @@ impl<T: Config> Pallet<T> {
 	pub fn get_door_ticket_sequence(
 		door_account: XRPLDoorAccount,
 	) -> Result<XrplTxTicketSequence, DispatchError> {
-		let mut current_sequence = Self::door_ticket_sequence(door_account);
-		let ticket_params = Self::door_ticket_sequence_params(door_account);
+		let mut current_sequence = DoorTicketSequence::<T>::get(door_account);
+		let ticket_params = DoorTicketSequenceParams::<T>::get(door_account);
 
 		// check if TicketSequenceThreshold reached. notify by emitting
 		// TicketSequenceThresholdReached
@@ -1707,7 +1703,7 @@ impl<T: Config> Pallet<T> {
 				current_sequence - ticket_params.start_sequence + 1,
 				ticket_params.bucket_size,
 			) >= T::TicketSequenceThreshold::get()
-			&& !Self::ticket_sequence_threshold_reached_emitted(door_account)
+			&& !TicketSequenceThresholdReachedEmitted::<T>::get(door_account)
 		{
 			Self::deposit_event(Event::<T>::TicketSequenceThresholdReached {
 				door_account,
@@ -1724,7 +1720,7 @@ impl<T: Config> Pallet<T> {
 			.ok_or(ArithmeticError::Overflow)?;
 		if current_sequence >= last_sequence {
 			// we ran out current bucket, check the next_start_sequence
-			let next_ticket_params = Self::door_ticket_sequence_params_next(door_account);
+			let next_ticket_params = DoorTicketSequenceParamsNext::<T>::get(door_account);
 			if next_ticket_params == XrplTicketSequenceParams::default()
 				|| next_ticket_params.start_sequence == ticket_params.start_sequence
 			{

--- a/pallet/xrpl-bridge/src/tests.rs
+++ b/pallet/xrpl-bridge/src/tests.rs
@@ -2543,12 +2543,12 @@ fn get_door_ticket_sequence_success_at_start_if_initial_params_not_set() {
 		));
 		assert_eq!(XRPLBridge::get_door_ticket_sequence(XRPLDoorAccount::Main), Ok(3));
 		assert_eq!(
-			XRPLBridge::ticket_sequence_threshold_reached_emitted(XRPLDoorAccount::Main),
+			TicketSequenceThresholdReachedEmitted::<Test>::get(XRPLDoorAccount::Main),
 			false
 		);
 		assert_eq!(XRPLBridge::get_door_ticket_sequence(XRPLDoorAccount::Main), Ok(4));
 		assert_eq!(
-			XRPLBridge::ticket_sequence_threshold_reached_emitted(XRPLDoorAccount::Main),
+			TicketSequenceThresholdReachedEmitted::<Test>::get(XRPLDoorAccount::Main),
 			true
 		);
 		System::assert_has_event(
@@ -2675,13 +2675,13 @@ fn get_door_ticket_sequence_check_events_emitted() {
 		));
 		assert_eq!(XRPLBridge::get_door_ticket_sequence(XRPLDoorAccount::Main), Ok(3));
 		assert_eq!(
-			XRPLBridge::ticket_sequence_threshold_reached_emitted(XRPLDoorAccount::Main),
+			TicketSequenceThresholdReachedEmitted::<Test>::get(XRPLDoorAccount::Main),
 			false
 		);
 		assert_eq!(XRPLBridge::get_door_ticket_sequence(XRPLDoorAccount::Main), Ok(4));
 		// event should be emitted here since ((4 - 3) + 1)/3 = 0.66 == TicketSequenceThreshold
 		assert_eq!(
-			XRPLBridge::ticket_sequence_threshold_reached_emitted(XRPLDoorAccount::Main),
+			TicketSequenceThresholdReachedEmitted::<Test>::get(XRPLDoorAccount::Main),
 			true
 		);
 		System::assert_has_event(

--- a/pallet/xrpl-bridge/src/tests.rs
+++ b/pallet/xrpl-bridge/src/tests.rs
@@ -2547,10 +2547,7 @@ fn get_door_ticket_sequence_success_at_start_if_initial_params_not_set() {
 			false
 		);
 		assert_eq!(XRPLBridge::get_door_ticket_sequence(XRPLDoorAccount::Main), Ok(4));
-		assert_eq!(
-			TicketSequenceThresholdReachedEmitted::<Test>::get(XRPLDoorAccount::Main),
-			true
-		);
+		assert_eq!(TicketSequenceThresholdReachedEmitted::<Test>::get(XRPLDoorAccount::Main), true);
 		System::assert_has_event(
 			Event::<Test>::TicketSequenceThresholdReached {
 				door_account: XRPLDoorAccount::Main,
@@ -2680,10 +2677,7 @@ fn get_door_ticket_sequence_check_events_emitted() {
 		);
 		assert_eq!(XRPLBridge::get_door_ticket_sequence(XRPLDoorAccount::Main), Ok(4));
 		// event should be emitted here since ((4 - 3) + 1)/3 = 0.66 == TicketSequenceThreshold
-		assert_eq!(
-			TicketSequenceThresholdReachedEmitted::<Test>::get(XRPLDoorAccount::Main),
-			true
-		);
+		assert_eq!(TicketSequenceThresholdReachedEmitted::<Test>::get(XRPLDoorAccount::Main), true);
 		System::assert_has_event(
 			Event::<Test>::TicketSequenceThresholdReached {
 				door_account: XRPLDoorAccount::Main,

--- a/runtime/src/tests/evm_tests.rs
+++ b/runtime/src/tests/evm_tests.rs
@@ -344,7 +344,7 @@ fn call_with_fee_preferences_futurepass_proxy_extrinsic() {
 fn transactions_cost_goes_to_tx_pot() {
 	ExtBuilder::default().build().execute_with(|| {
 		// Setup
-		let old_pot = TxFeePot::era_tx_fees();
+		let old_pot = pallet_tx_fee_pot::EraTxFees::<Runtime>::get();
 
 		// Call
 		let (origin, tx) = TxBuilder::default().build();
@@ -352,7 +352,7 @@ fn transactions_cost_goes_to_tx_pot() {
 
 		// Check
 		let expected_change = 157_500u128;
-		assert_eq!(TxFeePot::era_tx_fees(), old_pot + expected_change);
+		assert_eq!(pallet_tx_fee_pot::EraTxFees::<Runtime>::get(), old_pot + expected_change);
 	})
 }
 


### PR DESCRIPTION
# Description

- This PR removes the storage getter macros from pallets in favour of calling `::get()`

## Context & Background

- Substrate has deprecated the use of these macros in a future update so this work is needed for when we upgrade to Stable2409-1 

## Notes & Additional Information

- 

## Related Issues

- https://futureverse.atlassian.net/browse/TRN-733?atlOrigin=eyJpIjoiNWQ4ZmQ5ZGQ4OGQ3NDBlMjgyZjhmYmU1MzVhZTc4M2YiLCJwIjoiaiJ9

---

