### PR TITLE
ERC-165 support ERC-721 precompile

### DIFF
--- a/e2e/common/index.ts
+++ b/e2e/common/index.ts
@@ -256,6 +256,8 @@ const OWNABLE_ABI = [
   "function transferOwnership(address owner)",
 ];
 
+const ERC165_ABI = ["function supportsInterface(bytes4 interfaceId) public view returns (bool)"];
+
 export const FEE_PROXY_ABI_DEPRECATED = [
   "function callWithFeePreferences(address asset, uint128 maxPayment, address target, bytes input)",
 ];
@@ -331,6 +333,9 @@ export const ERC721_PRECOMPILE_ABI = [
 
   // Ownable
   ...OWNABLE_ABI,
+
+  // ERC165
+  ...ERC165_ABI,
 ];
 
 export const ERC1155_PRECOMPILE_ABI = [

--- a/e2e/contracts/ERC721PrecompileCaller.sol
+++ b/e2e/contracts/ERC721PrecompileCaller.sol
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity 0.8.17;
+
 import "@openzeppelin/contracts/interfaces/IERC721.sol";
 import "@openzeppelin/contracts/token/ERC721/extensions/IERC721Metadata.sol";
 
@@ -66,5 +67,118 @@ contract ERC721PrecompileCaller {
         uint256 tokenId
     ) external {
         IERC721(precompile).approve(who, tokenId);
+    }
+}
+
+contract ERC721PrecompileERC165Validator {
+    // Store interface IDs as constants after calculation
+    bytes4 public constant ERC165_ID = type(IERC165).interfaceId;
+    
+    // Calculate interface IDs based on function selectors
+    function calculateERC721InterfaceId() public pure returns (bytes4) {
+        return bytes4(
+            keccak256("balanceOf(address)") ^
+            keccak256("ownerOf(uint256)") ^
+            keccak256("safeTransferFrom(address,address,uint256)") ^
+            keccak256("transferFrom(address,address,uint256)") ^
+            keccak256("approve(address,uint256)") ^
+            keccak256("getApproved(uint256)") ^
+            keccak256("setApprovalForAll(address,bool)") ^
+            keccak256("isApprovedForAll(address,address)") ^
+            keccak256("safeTransferFrom(address,address,uint256,bytes)")
+        );
+    }
+
+    function calculateERC721MetadataInterfaceId() public pure returns (bytes4) {
+        return bytes4(
+            keccak256("name()") ^
+            keccak256("symbol()") ^
+            keccak256("tokenURI(uint256)")
+        );
+    }
+
+    function calculateERC721BurnableInterfaceId() public pure returns (bytes4) {
+        return bytes4(
+            keccak256("burn(uint256)")
+        );
+    }
+
+    function calculateTRN721InterfaceId() public pure returns (bytes4) {
+        return bytes4(
+            keccak256("totalSupply()") ^
+            keccak256("mint(address,uint32)") ^
+            keccak256("setMaxSupply(uint32)") ^
+            keccak256("setBaseURI(bytes)") ^
+            keccak256("ownedTokens(address,uint16,uint32)") ^
+            keccak256("togglePublicMint(bool)") ^
+            keccak256("setMintFee(address,uint256)")
+        );
+    }
+
+    function calculateOwnableInterfaceId() public pure returns (bytes4) {
+        return bytes4(
+            keccak256("owner()") ^
+            keccak256("renounceOwnership()") ^
+            keccak256("transferOwnership(address)")
+        );
+    }
+
+    // Validation functions
+    function validateContract(address contractAddress) public view returns (
+        bool supportsERC165,
+        bool supportsERC721,
+        bool supportsERC721Metadata,
+        bool supportsERC721Burnable,
+        bool supportsTRN721,
+        bool supportsOwnable
+    ) {
+        IERC165 target = IERC165(contractAddress);
+        
+        // First check ERC165 support
+        try target.supportsInterface(ERC165_ID) returns (bool erc165Support) {
+            supportsERC165 = erc165Support;
+            
+            if (erc165Support) {
+                // Only check other interfaces if ERC165 is supported
+                try target.supportsInterface(calculateERC721InterfaceId()) returns (bool support) {
+                    supportsERC721 = support;
+                } catch {}
+                
+                try target.supportsInterface(calculateERC721MetadataInterfaceId()) returns (bool support) {
+                    supportsERC721Metadata = support;
+                } catch {}
+                
+                try target.supportsInterface(calculateERC721BurnableInterfaceId()) returns (bool support) {
+                    supportsERC721Burnable = support;
+                } catch {}
+                
+                try target.supportsInterface(calculateTRN721InterfaceId()) returns (bool support) {
+                    supportsTRN721 = support;
+                } catch {}
+                
+                try target.supportsInterface(calculateOwnableInterfaceId()) returns (bool support) {
+                    supportsOwnable = support;
+                } catch {}
+            }
+        } catch {}
+    }
+
+    // Get all interface IDs at once
+    function getAllInterfaceIds() public pure returns (
+        bytes4 erc165,
+        bytes4 erc721,
+        bytes4 erc721Metadata,
+        bytes4 erc721Burnable,
+        bytes4 trn721,
+        bytes4 ownable
+    ) {
+        return (
+            ERC165_ID,
+            calculateERC721InterfaceId(),
+            calculateERC721MetadataInterfaceId(),
+            calculateERC721BurnableInterfaceId(),
+            calculateTRN721InterfaceId(),
+            calculateOwnableInterfaceId()
+        );
     }
 }

--- a/evm-precompiles/erc721/README.md
+++ b/evm-precompiles/erc721/README.md
@@ -3,6 +3,12 @@
 Precompile address spec: `0xAAAAAAAA[4-byte-collection-id]000000000000000000000000`
 
 ```solidity
+interface IERC165 {
+    function supportsInterface(bytes4 interfaceId) external view returns (bool);
+}
+```
+
+```solidity
 interface IERC721 is IERC165 {
     event Transfer(address indexed from, address indexed to, uint256 indexed tokenId);
     event Approval(address indexed owner, address indexed approved, uint256 indexed tokenId);

--- a/evm-precompiles/erc721/src/lib.rs
+++ b/evm-precompiles/erc721/src/lib.rs
@@ -31,7 +31,7 @@ use seed_pallet_common::NFTExt;
 use seed_primitives::{
 	AssetId, Balance, CollectionUuid, EthAddress, SerialNumber, TokenCount, TokenId,
 };
-use sp_core::{H160, H256, U256};
+use sp_core::{Encode, H160, H256, U256};
 use sp_runtime::{traits::SaturatedConversion, BoundedVec};
 use sp_std::{marker::PhantomData, vec, vec::Vec};
 
@@ -68,6 +68,16 @@ pub const SELECTOR_LOG_MINT_FEE_UPDATED: [u8; 32] = keccak256!("MintFeeUpdated(a
 /// Solidity selector of the onERC721Received(address,address,uint256,bytes) function
 pub const ON_ERC721_RECEIVED_FUNCTION_SELECTOR: [u8; 4] = [0x15, 0x0b, 0x7a, 0x02];
 
+/// Interface IDs for the ERC721, ERC721Metadata, ERC721Burnable, Ownable, and TRN721 interfaces
+pub const ERC165_INTERFACE_IDS: &[u32] = &[
+	0x01ffc9a7, // ERC165
+	0x80ac58cd, // ERC721
+	0x5b5e139f, // ERC721Metadata
+	0x42966c68, // ERC721Burnable
+	0x0e083076, // Ownable
+	0x2a4288ec, // TRN721
+];
+
 #[precompile_utils::generate_function_selector]
 #[derive(Debug, PartialEq)]
 pub enum Action {
@@ -103,6 +113,8 @@ pub enum Action {
 	// XLS-20 extensions
 	EnableXls20Compatibility = "enableXls20Compatibility()",
 	ReRequestXls20Mint = "reRequestXls20Mint(uint32[])",
+	// ERC165 - https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/utils/introspection/ERC165.sol
+	SupportsInterface = "supportsInterface(bytes4)",
 }
 
 /// The following distribution has been decided for the precompiles
@@ -223,6 +235,8 @@ where
 						Action::ReRequestXls20Mint => {
 							Self::re_request_xls20_mint(collection_id, handle)
 						},
+						// ERC165
+						Action::SupportsInterface => Self::supports_interface(handle),
 						_ => return Some(Err(revert("ERC721: Function not implemented"))),
 					}
 				};
@@ -1148,5 +1162,27 @@ where
 
 		// Build output.
 		Ok(succeed(EvmDataWriter::new().write(true).build()))
+	}
+
+	fn supports_interface(handle: &mut impl PrecompileHandle) -> EvmResult<PrecompileOutput> {
+		handle.record_log_costs_manual(1, 32)?;
+		read_args!(handle, { interface_id: U256 });
+
+		// Convert to bytes4 by getting the last 4 bytes of the BE representation
+		let interface_id_bytes = interface_id.encode();
+		let interface_id_u32 = u32::from_le_bytes(
+			interface_id_bytes[28..32]
+				.try_into()
+				.map_err(|_| revert("ERC165: Invalid interface ID"))?,
+		);
+
+		// ERC165 requires returning false for 0xffffffff
+		// https://eips.ethereum.org/EIPS/eip-165#how-a-contract-will-publish-the-interfaces-it-implements
+		if interface_id_u32 == 0xffffffff {
+			return Ok(succeed(EvmDataWriter::new().write(false).build()));
+		}
+
+		let supported = ERC165_INTERFACE_IDS.contains(&interface_id_u32);
+		Ok(succeed(EvmDataWriter::new().write(supported).build()))
 	}
 }


### PR DESCRIPTION
# PR Description

# Description

This PR adds `ERC165` support to the `ERC721` precompile.
The `ERC721` precompile satisfies the following interfaces:
- `ERC165`
- `ERC721`
- `ERC721Metadata`
- `ERC721Burnable`
- `Ownable`
- `TRN721`

With this support, any contract can validate that the ERC721 precompile satisfies the the above Interfaces on-chain.
Relevant E2E tests have been added validate this.

## Implementation Details

To calculate the interface ID for each of these interfaces:
- `keccak256` hash each of the selectors for the functions in the interface
- XOR the results together
- Take the last 4 bytes of the result; this is the interface ID
- Do this for all of the supported interfaces
- To validate whether a contract implements an interface, a contract must implement the `supportsInterface(bytes4)` function and check if the provided interface ID is equal to any of the interface IDs it supports

## Notes

- The `ERC165` interface ID is `0x01ffc9a7`.
- The `ERC721` interface ID is `0x80ac58cd`.
- The `ERC721Metadata` interface ID is `0x5b5e139f`.
- The `ERC721Burnable` interface ID is `0x42966c68`.
- The `Ownable` interface ID is `0x0e083076`.
- The `TRN721` interface ID is `0x2a4288ec`.

- A solidity contract `ERC721PrecompileERC165Validator` is provided to generate the interface IDs for the supported interfaces and validate them against the `ERC721` precompile
- E2E tests have been written to validate the `ERC165` support for the `ERC721` precompile

---

# Release Notes

## Key Changes

- `ERC165` support added to the `ERC721` precompile

## Type of Change

- [x] Runtime Changes
- [ ] Client Changes

## API Changes

### EVM Precompile Changes

#### Added

- **ERC721: `supportsInterface(bytes4)`**

---
