### PR TITLE
ERC-165 support ERC-20 and ERC-1155 EVM precompiles

### DIFF
--- a/e2e/common/index.ts
+++ b/e2e/common/index.ts
@@ -357,15 +357,15 @@ export const ERC1155_PRECOMPILE_ABI = [
   "function safeTransferFrom(address from, address to, uint256 id, uint256 amount, bytes calldata data) external",
   "function safeBatchTransferFrom(address from, address to, uint256[] calldata ids, uint256[] calldata amounts, bytes calldata data) external",
 
-  // Burnable
+  // ERC1155Burnable
   "function burn(address account, uint256 id, uint256 value) external",
   "function burnBatch(address account, uint256[] ids, uint256[] values) external",
 
-  // Supply
+  // ERC1155Supply
   "function totalSupply(uint256 id) external view returns (uint256)",
   "function exists(uint256 id) external view returns (bool)",
 
-  // Metadata
+  // ERC1155MetadataURI
   "function uri(uint256 id) external view returns (string memory)",
 
   // TRN
@@ -385,6 +385,9 @@ export const ERC1155_PRECOMPILE_ABI = [
 
   // Ownable
   ...OWNABLE_ABI,
+
+  // ERC165
+  ...ERC165_ABI,
 ];
 
 export const FUTUREPASS_REGISTRAR_PRECOMPILE_ABI = [

--- a/e2e/common/index.ts
+++ b/e2e/common/index.ts
@@ -264,17 +264,23 @@ export const FEE_PROXY_ABI_DEPRECATED = [
 export const FEE_PROXY_ABI = ["function callWithFeePreferences(address asset, address target, bytes input)"];
 
 export const ERC20_ABI = [
+  // ERC20
   "event Transfer(address indexed from, address indexed to, uint256 value)",
   "event Approval(address indexed owner, address indexed spender, uint256 value)",
   "function approve(address spender, uint256 amount) public returns (bool)",
   "function allowance(address owner, address spender) public view returns (uint256)",
   "function balanceOf(address who) public view returns (uint256)",
-  "function name() public view returns (string memory)",
-  "function symbol() public view returns (string memory)",
-  "function decimals() public view returns (uint8)",
   "function totalSupply() external view returns (uint256)",
   "function transfer(address who, uint256 amount)",
   "function transferFrom(address from, address to, uint256 amount)",
+
+  // ERC20 Metadata
+  "function name() public view returns (string memory)",
+  "function symbol() public view returns (string memory)",
+  "function decimals() public view returns (uint8)",
+
+  // ERC165
+  ...ERC165_ABI,
 ];
 
 export const NFT_PRECOMPILE_ABI = [

--- a/e2e/contracts/ERC1155PrecompileCaller.sol
+++ b/e2e/contracts/ERC1155PrecompileCaller.sol
@@ -50,3 +50,121 @@ contract ERC1155PrecompileCaller {
         return IERC1155MetadataURI(precompile).uri(id);
     }
 }
+
+contract ERC1155PrecompileERC165Validator {
+    // Store ERC165 interface ID as constant
+    bytes4 public constant ERC165_ID = type(IERC165).interfaceId;
+    
+    function calculateERC1155InterfaceId() public pure returns (bytes4) {
+        return bytes4(
+            keccak256("balanceOf(address,uint256)") ^
+            keccak256("balanceOfBatch(address[],uint256[])") ^
+            keccak256("setApprovalForAll(address,bool)") ^
+            keccak256("isApprovedForAll(address,address)") ^
+            keccak256("safeTransferFrom(address,address,uint256,uint256,bytes)") ^
+            keccak256("safeBatchTransferFrom(address,address,uint256[],uint256[],bytes)")
+        );
+    }
+
+    function calculateERC1155BurnableInterfaceId() public pure returns (bytes4) {
+        return bytes4(
+            keccak256("burn(address,uint256,uint256)") ^
+            keccak256("burnBatch(address,uint256[],uint256[])")
+        );
+    }
+
+    function calculateERC1155SupplyInterfaceId() public pure returns (bytes4) {
+        return bytes4(
+            keccak256("totalSupply(uint256)") ^
+            keccak256("exists(uint256)")
+        );
+    }
+
+    function calculateERC1155MetadataURIInterfaceId() public pure returns (bytes4) {
+        return bytes4(
+            keccak256("uri(uint256)")
+        );
+    }
+
+    function calculateTRN1155InterfaceId() public pure returns (bytes4) {
+        return bytes4(
+            keccak256("createToken(bytes,uint128,uint128,address)") ^
+            keccak256("mint(address,uint256,uint256)") ^
+            keccak256("mintBatch(address,uint256[],uint256[])") ^
+            keccak256("setMaxSupply(uint256,uint32)") ^
+            keccak256("setBaseURI(bytes)") ^
+            keccak256("togglePublicMint(uint256,bool)") ^
+            keccak256("setMintFee(uint256,address,uint256)")
+        );
+    }
+
+    function calculateOwnableInterfaceId() public pure returns (bytes4) {
+        return bytes4(
+            keccak256("owner()") ^
+            keccak256("renounceOwnership()") ^
+            keccak256("transferOwnership(address)")
+        );
+    }
+
+    function validateContract(address contractAddress) public view returns (
+        bool supportsERC165,
+        bool supportsERC1155,
+        bool supportsERC1155Burnable,
+        bool supportsERC1155Supply,
+        bool supportsERC1155MetadataURI,
+        bool supportsTRN1155,
+        bool supportsOwnable
+    ) {
+        IERC165 target = IERC165(contractAddress);
+        
+        try target.supportsInterface(ERC165_ID) returns (bool erc165Support) {
+            supportsERC165 = erc165Support;
+            
+            if (erc165Support) {
+                try target.supportsInterface(calculateERC1155InterfaceId()) returns (bool support) {
+                    supportsERC1155 = support;
+                } catch {}
+                
+                try target.supportsInterface(calculateERC1155BurnableInterfaceId()) returns (bool support) {
+                    supportsERC1155Burnable = support;
+                } catch {}
+
+                try target.supportsInterface(calculateERC1155SupplyInterfaceId()) returns (bool support) {
+                    supportsERC1155Supply = support;
+                } catch {}
+
+                try target.supportsInterface(calculateERC1155MetadataURIInterfaceId()) returns (bool support) {
+                    supportsERC1155MetadataURI = support;
+                } catch {}
+
+                try target.supportsInterface(calculateTRN1155InterfaceId()) returns (bool support) {
+                    supportsTRN1155 = support;
+                } catch {}
+
+                try target.supportsInterface(calculateOwnableInterfaceId()) returns (bool support) {
+                    supportsOwnable = support;
+                } catch {}
+            }
+        } catch {}
+    }
+
+    function getAllInterfaceIds() public pure returns (
+        bytes4 erc165,
+        bytes4 erc1155,
+        bytes4 erc1155Burnable,
+        bytes4 erc1155Supply,
+        bytes4 erc1155MetadataURI,
+        bytes4 trn1155,
+        bytes4 ownable
+    ) {
+        return (
+            ERC165_ID,
+            calculateERC1155InterfaceId(),
+            calculateERC1155BurnableInterfaceId(),
+            calculateERC1155SupplyInterfaceId(),
+            calculateERC1155MetadataURIInterfaceId(),
+            calculateTRN1155InterfaceId(),
+            calculateOwnableInterfaceId()
+        );
+    }
+}

--- a/e2e/contracts/Erc20PrecompileCaller.sol
+++ b/e2e/contracts/Erc20PrecompileCaller.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity 0.8.17;
+
 import "@openzeppelin/contracts/interfaces/IERC20.sol";
+import "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 
 // Calls Root network ERC20 precompile
 contract ERC20PrecompileCaller {
@@ -30,5 +32,63 @@ contract ERC20PrecompileCaller {
             total += (uint256(amounts_6[i]) * uint256(1e12));
             require(total == address(destination).balance, "unexpected balance");
         }
+    }
+}
+
+contract ERC20PrecompileERC165Validator {
+    // Store ERC165 interface ID as constant
+    bytes4 public constant ERC165_ID = type(IERC165).interfaceId;
+    
+    function calculateERC20InterfaceId() public pure returns (bytes4) {
+        return bytes4(
+            keccak256("totalSupply()") ^
+            keccak256("balanceOf(address)") ^
+            keccak256("transfer(address,uint256)") ^
+            keccak256("allowance(address,address)") ^
+            keccak256("approve(address,uint256)") ^
+            keccak256("transferFrom(address,address,uint256)")
+        );
+    }
+
+    function calculateERC20MetadataInterfaceId() public pure returns (bytes4) {
+        return bytes4(
+            keccak256("name()") ^
+            keccak256("symbol()") ^
+            keccak256("decimals()")
+        );
+    }
+
+    function validateContract(address contractAddress) public view returns (
+        bool supportsERC165,
+        bool supportsERC20,
+        bool supportsERC20Metadata
+    ) {
+        IERC165 target = IERC165(contractAddress);
+        
+        try target.supportsInterface(ERC165_ID) returns (bool erc165Support) {
+            supportsERC165 = erc165Support;
+            
+            if (erc165Support) {
+                try target.supportsInterface(calculateERC20InterfaceId()) returns (bool support) {
+                    supportsERC20 = support;
+                } catch {}
+                
+                try target.supportsInterface(calculateERC20MetadataInterfaceId()) returns (bool support) {
+                    supportsERC20Metadata = support;
+                } catch {}
+            }
+        } catch {}
+    }
+
+    function getAllInterfaceIds() public pure returns (
+        bytes4 erc165,
+        bytes4 erc20,
+        bytes4 erc20Metadata
+    ) {
+        return (
+            ERC165_ID,
+            calculateERC20InterfaceId(),
+            calculateERC20MetadataInterfaceId()
+        );
     }
 }

--- a/e2e/test/ERC1155/ERC1155Precompile.test.ts
+++ b/e2e/test/ERC1155/ERC1155Precompile.test.ts
@@ -690,4 +690,78 @@ describe("ERC1155 Precompile", function () {
     // Check ownership is now zero address
     expect(await erc1155Precompile.owner()).to.equal(constants.AddressZero);
   });
+
+  it("supportsInterface", async () => {
+    // ERC165
+    expect(await erc1155Precompile.supportsInterface(0x01ffc9a7)).to.be.true;
+    // ERC1155
+    expect(await erc1155Precompile.supportsInterface(0xd9b67a26)).to.be.true;
+    // ERC1155Burnable
+    expect(await erc1155Precompile.supportsInterface(0x9e094e9e)).to.be.true;
+    // ERC1155MetadataURI
+    expect(await erc1155Precompile.supportsInterface(0x0e89341c)).to.be.true;
+    // ERC1155Supply
+    expect(await erc1155Precompile.supportsInterface(0xf2d03e40)).to.be.true;
+    // TRN1155
+    expect(await erc1155Precompile.supportsInterface(0xf0f03f65)).to.be.true;
+    // Ownable
+    expect(await erc1155Precompile.supportsInterface(0x0e083076)).to.be.true;
+  });
+
+  it("supportsInterface via contract", async () => {
+    // Deploy ERC1155PrecompileERC165Validator contract
+    const factory = await ethers.getContractFactory("ERC1155PrecompileERC165Validator");
+    const validator = await factory.connect(alithSigner).deploy();
+    await validator.deployed();
+
+    // Get all interface IDs from the validator contract
+    const {
+      erc165: erc165Id,
+      erc1155: erc1155Id,
+      erc1155Burnable: erc1155BurnableId,
+      erc1155MetadataURI: erc1155MetadataURIId,
+      erc1155Supply: erc1155SupplyId,
+      trn1155: trn1155Id,
+      ownable: ownableId,
+    } = await validator.getAllInterfaceIds();
+
+    // Validate individual interfaces
+    expect(await erc1155Precompile.supportsInterface(erc165Id)).to.be.true;
+    expect(await erc1155Precompile.supportsInterface(erc1155Id)).to.be.true;
+    expect(await erc1155Precompile.supportsInterface(erc1155BurnableId)).to.be.true;
+    expect(await erc1155Precompile.supportsInterface(erc1155MetadataURIId)).to.be.true;
+    expect(await erc1155Precompile.supportsInterface(erc1155SupplyId)).to.be.true;
+    expect(await erc1155Precompile.supportsInterface(trn1155Id)).to.be.true;
+    expect(await erc1155Precompile.supportsInterface(ownableId)).to.be.true;
+
+    // Validate using the contract's validation function
+    const [
+      supportsERC165,
+      supportsERC1155,
+      supportsERC1155Burnable,
+      supportsERC1155MetadataURI,
+      supportsERC1155Supply,
+      supportsTrn1155,
+      supportsOwnable,
+    ] = await validator.validateContract(erc1155Precompile.address);
+
+    // Assert all interfaces are supported
+    expect(supportsERC165).to.be.true;
+    expect(supportsERC1155).to.be.true;
+    expect(supportsERC1155Burnable).to.be.true;
+    expect(supportsERC1155MetadataURI).to.be.true;
+    expect(supportsERC1155Supply).to.be.true;
+    expect(supportsTrn1155).to.be.true;
+    expect(supportsOwnable).to.be.true;
+
+    // // Log the interface IDs for reference
+    // console.log("Interface IDs:");
+    // console.log("ERC165:", erc165Id);
+    // console.log("ERC1155:", erc1155Id);
+    // console.log("ERC1155Burnable:", erc1155BurnableId);
+    // console.log("ERC1155MetadataURI:", erc1155MetadataURIId);
+    // console.log("ERC1155Supply:", erc1155SupplyId);
+    // console.log("TRN1155:", trn1155Id);
+    // console.log("Ownable:", ownableId);
+  });
 });

--- a/evm-precompiles/erc1155/README.md
+++ b/evm-precompiles/erc1155/README.md
@@ -3,6 +3,12 @@
 Precompile address spec: `0xBBBBBBBB[4-byte-collection-id]000000000000000000000000`
 
 ```solidity
+interface IERC165 {
+    function supportsInterface(bytes4 interfaceId) external view returns (bool);
+}
+```
+
+```solidity
 interface IERC1155 is IERC165 {
     event TransferSingle(address indexed operator, address indexed from, address indexed to, uint256 id, uint256 value);
     event TransferBatch(address indexed operator, address indexed from, address indexed to, uint256[] ids, uint256[] values);

--- a/evm-precompiles/erc20/README.md
+++ b/evm-precompiles/erc20/README.md
@@ -3,6 +3,12 @@
 Precompile address spec: `0xCCCCCCCC[4-byte-token-id]000000000000000000000000`
 
 ```solidity
+interface IERC165 {
+    function supportsInterface(bytes4 interfaceId) external view returns (bool);
+}
+```
+
+```solidity
 interface IERC20 is IERC165 {
     event Transfer(address indexed from, address indexed to, uint256 value);
     event Approval(address indexed owner, address indexed spender, uint256 value);

--- a/evm-precompiles/erc721/src/lib.rs
+++ b/evm-precompiles/erc721/src/lib.rs
@@ -68,7 +68,7 @@ pub const SELECTOR_LOG_MINT_FEE_UPDATED: [u8; 32] = keccak256!("MintFeeUpdated(a
 /// Solidity selector of the onERC721Received(address,address,uint256,bytes) function
 pub const ON_ERC721_RECEIVED_FUNCTION_SELECTOR: [u8; 4] = [0x15, 0x0b, 0x7a, 0x02];
 
-/// Interface IDs for the ERC721, ERC721Metadata, ERC721Burnable, Ownable, and TRN721 interfaces
+/// Interface IDs for the ERC165, ERC721, ERC721Metadata, ERC721Burnable, Ownable, and TRN721 interfaces
 pub const ERC165_INTERFACE_IDS: &[u32] = &[
 	0x01ffc9a7, // ERC165
 	0x80ac58cd, // ERC721


### PR DESCRIPTION
# Description

This PR adds ERC165 support to the ERC20 and ERC1155 precompiles.

The ERC20 precompile satisfies the following interfaces:
- ERC165
- ERC20
- ERC20Metadata

The ERC1155 precompile satisfies the following interfaces:
- ERC165
- ERC1155
- ERC1155Burnable
- ERC1155Supply
- ERC1155MetadataURI
- Ownable
- TRN1155

With this support, any contract can validate that the ERC20 and ERC1155 precompiles satisfies the the above Interfaces on-chain.
Relevant E2E tests have been added validate this.

## Implementation Details

To calculate the interface ID for each of these interfaces:
- `keccak256` hash each of the selectors for the functions in the interface
- XOR the results together
- Take the last 4 bytes of the result; this is the interface ID
- Do this for all of the supported interfaces
- To validate whether a contract implements an interface, a contract must implement the `supportsInterface(bytes4)` function and check if the provided interface ID is equal to any of the interface IDs it supports

## Notes

### ERC165 Interface IDs for ERC20:
- The `ERC165` interface ID is `0x01ffc9a7`
- The `ERC20` interface ID is `0x36372b07`
- The `ERC20Metadata` interface ID is `0xa219a025`

### ERC165 Interface IDs for ERC1155:
- The `ERC165` interface ID is `0x01ffc9a7`
- The `ERC1155` interface ID is `0x80ac58cd`
- The `ERC1155Burnable` interface ID is `0x5b5e139f`
- The `ERC1155Supply` interface ID is `0x5b5e139f`
- The `ERC1155MetadataURI` interface ID is `0x5b5e139f`
- The `Ownable` interface ID is `0x0e083076`
- The `TRN1155` interface ID is `0x2a4288ec`

---

# Release Notes

## Key Changes

- `ERC165` support added to the `ERC20` precompile
- `ERC165` support added to the `ERC1155` precompile

## Type of Change

- [x] Runtime Changes
- [ ] Client Changes

## API Changes

### EVM Precompile Changes

#### Added

- **ERC20: `supportsInterface(bytes4)`**
- **ERC1155: `supportsInterface(bytes4)`**