### PR TITLE
Pass attribution partner fee accumulation via fee-proxy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5858,6 +5858,7 @@ dependencies = [
  "pallet-evm",
  "pallet-fee-control",
  "pallet-futurepass",
+ "pallet-partner-attribution",
  "pallet-proxy",
  "pallet-sylo-data-verification",
  "pallet-timestamp",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5826,6 +5826,7 @@ dependencies = [
  "pallet-evm",
  "pallet-fee-proxy",
  "pallet-futurepass",
+ "pallet-partner-attribution",
  "pallet-proxy",
  "pallet-sylo-data-verification",
  "pallet-timestamp",

--- a/pallet/common/src/test_utils.rs
+++ b/pallet/common/src/test_utils.rs
@@ -811,6 +811,8 @@ macro_rules! impl_pallet_partner_attribution_config {
 					_ => Err(o),
 				}
 			}
+
+			// Add "pallet-partner-attribution/runtime-benchmarks" to runtime-benchmarks feature of dependent pallet
 			#[cfg(feature = "runtime-benchmarks")]
 			fn try_successful_origin() -> Result<<Test as frame_system::Config>::RuntimeOrigin, ()>
 			{
@@ -848,6 +850,8 @@ macro_rules! impl_pallet_partner_attribution_config {
 			type EnsureFuturepass = EnsureAny;
 			type FuturepassCreator = MockFuturepassProvider;
 			type WeightInfo = ();
+			#[cfg(feature = "runtime-benchmarks")]
+			type MultiCurrency = AssetsExt;
 		}
 	};
 }

--- a/pallet/common/src/test_utils.rs
+++ b/pallet/common/src/test_utils.rs
@@ -798,6 +798,61 @@ macro_rules! impl_pallet_xrpl_config {
 }
 
 #[macro_export]
+macro_rules! impl_pallet_partner_attribution_config {
+	($test:ident) => {
+		pub struct EnsureAny;
+		impl EnsureOrigin<<Test as frame_system::Config>::RuntimeOrigin> for EnsureAny {
+			type Success = H160;
+			fn try_origin(
+				o: <Test as frame_system::Config>::RuntimeOrigin,
+			) -> Result<Self::Success, <Test as frame_system::Config>::RuntimeOrigin> {
+				match o.clone().into() {
+					Ok(RawOrigin::Signed(who)) => Ok(who.into()),
+					_ => Err(o),
+				}
+			}
+			#[cfg(feature = "runtime-benchmarks")]
+			fn try_successful_origin() -> Result<<Test as frame_system::Config>::RuntimeOrigin, ()>
+			{
+				Ok(RawOrigin::Root.into())
+			}
+		}
+
+		pub struct MockFuturepassProvider;
+
+		impl FuturepassProvider for MockFuturepassProvider {
+			type AccountId = AccountId;
+
+			fn create_futurepass(
+				_funder: Self::AccountId,
+				owner: Self::AccountId,
+			) -> Result<Self::AccountId, DispatchError> {
+				// Create a deterministic account by hashing the owner's address with a prefix
+				let mut input = Vec::with_capacity(24);
+				// Use a fixed prefix for futurepass accounts (first 4 bytes)
+				input.extend_from_slice(&[0xff, 0xff, 0xff, 0xff]);
+				// Add the owner's account bytes
+				input.extend_from_slice(&owner.encode());
+
+				// Hash the input to get a deterministic address
+				let hash = sp_core::hashing::blake2_256(&input);
+				let address = H160::from_slice(&hash[0..20]);
+
+				Ok(address.into())
+			}
+		}
+
+		impl pallet_partner_attribution::Config for Test {
+			type RuntimeEvent = RuntimeEvent;
+			type ApproveOrigin = EnsureRoot<AccountId>;
+			type EnsureFuturepass = EnsureAny;
+			type FuturepassCreator = MockFuturepassProvider;
+			type WeightInfo = ();
+		}
+	};
+}
+
+#[macro_export]
 macro_rules! impl_pallet_utility_config {
 	($test:ident) => {
 		impl pallet_utility::Config for Test {

--- a/pallet/fee-control/Cargo.toml
+++ b/pallet/fee-control/Cargo.toml
@@ -43,6 +43,7 @@ pallet-xrpl = { workspace = true }
 pallet-proxy = { workspace = true }
 pallet-utility = { workspace = true }
 seed-pallet-common= { workspace = true, default-features = true }
+pallet-partner-attribution = { workspace = true }
 
 [features]
 default = ["std"]
@@ -65,4 +66,4 @@ std = [
 	"frame-benchmarking?/std",
 ]
 try-runtime = ["frame-support/try-runtime"]
-runtime-benchmarks = ["frame-benchmarking"]
+runtime-benchmarks = ["frame-benchmarking", "pallet-partner-attribution/runtime-benchmarks"]

--- a/pallet/fee-control/src/mock.rs
+++ b/pallet/fee-control/src/mock.rs
@@ -47,6 +47,7 @@ construct_runtime!(
 		Utility: pallet_utility,
 		Proxy: pallet_proxy,
 		FeeControl: pallet_fee_control,
+		PartnerAttribution: pallet_partner_attribution,
 	}
 );
 
@@ -65,7 +66,7 @@ impl_pallet_xrpl_config!(Test);
 impl_pallet_proxy_config!(Test);
 impl_pallet_utility_config!(Test);
 impl_pallet_fee_control_config!(Test);
-
+impl_pallet_partner_attribution_config!(Test);
 impl mock_pallet::pallet::Config for Test {}
 // Mock pallet for testing extrinsics with a specific weight
 pub mod mock_pallet {

--- a/pallet/fee-proxy/Cargo.toml
+++ b/pallet/fee-proxy/Cargo.toml
@@ -65,5 +65,5 @@ std = [
     "frame-system/std",
     "frame-benchmarking?/std",
 ]
-runtime-benchmarks = ["frame-benchmarking"]
+runtime-benchmarks = ["frame-benchmarking", "pallet-partner-attribution/runtime-benchmarks"]
 try-runtime = ["frame-support/try-runtime"]

--- a/pallet/fee-proxy/Cargo.toml
+++ b/pallet/fee-proxy/Cargo.toml
@@ -27,6 +27,7 @@ pallet-proxy = { workspace = true }
 pallet-utility = { workspace = true }
 pallet-xrpl = { workspace = true }
 pallet-sylo-data-verification = { workspace = true }
+pallet-partner-attribution = { workspace = true }
 pallet-transaction-payment = { workspace = true }
 precompile-utils = { workspace = true }
 
@@ -52,6 +53,7 @@ std = [
 	"pallet-utility/std",
     "pallet-evm/std",
     "pallet-sylo-data-verification/std",
+    "pallet-partner-attribution/std",
     "pallet-transaction-payment/std",
     "scale-info/std",
     "seed-primitives/std",

--- a/pallet/fee-proxy/src/mock.rs
+++ b/pallet/fee-proxy/src/mock.rs
@@ -44,6 +44,7 @@ construct_runtime!(
 		Xrpl: pallet_xrpl,
 		Utility: pallet_utility,
 		Proxy: pallet_proxy,
+		PartnerAttribution: pallet_partner_attribution,
 	}
 );
 
@@ -61,6 +62,7 @@ impl_pallet_sylo_data_verification_config!(Test);
 impl_pallet_xrpl_config!(Test);
 impl_pallet_proxy_config!(Test);
 impl_pallet_utility_config!(Test);
+impl_pallet_partner_attribution_config!(Test);
 
 // Mock ErcIdConversion for testing purposes
 impl<RuntimeId> ErcIdConversion<RuntimeId> for Test

--- a/pallet/fee-proxy/src/tests.rs
+++ b/pallet/fee-proxy/src/tests.rs
@@ -491,14 +491,8 @@ mod partner_fee_attribution {
 				)
 				.expect("Fee withdrawal should work");
 
-				// Verify partner's accumulated fees increased
+				// Verify partner's accumulated fees increased deterministically
 				let updated_partner = Partners::<Test>::get(partner_id).unwrap();
-				assert!(
-					updated_partner.accumulated_fees > 0,
-					"Partner should have accumulated fees"
-				);
-
-				// verify the exact fee amount if deterministic
 				assert_eq!(
 					updated_partner.accumulated_fees, fee,
 					"Partner should have accumulated correct fee amount"

--- a/pallet/fee-proxy/src/tests.rs
+++ b/pallet/fee-proxy/src/tests.rs
@@ -440,3 +440,69 @@ mod calculate_total_gas {
 		});
 	}
 }
+
+mod partner_fee_attribution {
+	use super::*;
+	use crate::mock::{AssetsExt, RuntimeCall};
+	use frame_support::{dispatch::DispatchInfo, sp_runtime::Permill, traits::fungibles::Mutate};
+	use pallet_partner_attribution::{Attributions, PartnerInformation, Partners};
+	use pallet_transaction_payment::OnChargeTransaction;
+
+	#[test]
+	fn successful_partner_fee_attribution() {
+		TestExt::<Test>::default()
+			.with_asset(XRP_ASSET_ID, "XRP", &[]) // create XRP asset
+			.build()
+			.execute_with(|| {
+				// Setup
+				let caller: AccountId = create_account(1);
+				let partner_account: AccountId = create_account(2);
+				let partner_id = 1u128;
+				let initial_balance = 1_000_000;
+
+				// Give caller some balance - to perform tx (pay for fees)
+				assert_ok!(AssetsExt::mint_into(XRP_ASSET_ID, &caller, initial_balance));
+
+				// Register partner and set fee percentage
+				let partner = PartnerInformation {
+					owner: partner_account.clone(),
+					account: partner_account.clone(),
+					fee_percentage: Some(Permill::from_percent(10)),
+					accumulated_fees: 0,
+				};
+				Partners::<Test>::insert(partner_id, partner);
+
+				// Attribute caller to partner
+				Attributions::<Test>::insert(&caller, partner_id);
+
+				// Create a transaction that will incur fees
+				let call = RuntimeCall::System(frame_system::Call::remark {
+					remark: b"Test Transaction".to_vec(),
+				});
+
+				// Calculate and charge the fee
+				let fee = 500;
+				let _ = FeeProxy::withdraw_fee(
+					&caller,
+					&call,
+					&DispatchInfo::default(),
+					fee.into(),
+					0u32.into(),
+				)
+				.expect("Fee withdrawal should work");
+
+				// Verify partner's accumulated fees increased
+				let updated_partner = Partners::<Test>::get(partner_id).unwrap();
+				assert!(
+					updated_partner.accumulated_fees > 0,
+					"Partner should have accumulated fees"
+				);
+
+				// verify the exact fee amount if deterministic
+				assert_eq!(
+					updated_partner.accumulated_fees, fee,
+					"Partner should have accumulated correct fee amount"
+				);
+			});
+	}
+}


### PR DESCRIPTION
# Description

- Updated the `FeeProxy` pallet to allow partners to accumulate fees via the `PartnerAttribution` pallet - if the partner has a fee percentage set (by an admin account).
- Added unit tests + mocks
- Added E2E test to validate partner fee accumulation on FP transaction

---

# Release Notes

## Key Changes
- Updated the `FeeProxy` pallet to allow partners to accumulate fees via the `PartnerAttribution` pallet - if the partner has a fee percentage set (by an admin account).

## Type of Change

- [x] Runtime Changes
- [ ] Client Changes

---
