### PR TITLE
Release 10.68.0

### DIFF
--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -159,7 +159,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("root"),
 	impl_name: create_runtime_str!("root"),
 	authoring_version: 1,
-	spec_version: 67,
+	spec_version: 68,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 13,


### PR DESCRIPTION
# Release

**Release Name:** `10.68.0`

**Spec Version:** `68`

**Client Version:** `10.0.0`

## Key Changes:

This release introduces the following changes:

- Add variable benchmarks to NFT pallet

## PRs included:
- https://github.com/futureversecom/trn-seed/pull/932

---

## Client Changes:
- [ ] Yes
- [x] No

## Runtime Changes:
- [x] Yes
- [ ] No

