### PR TITLE
Release 10.70.0

### DIFF
--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -159,10 +159,10 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("root"),
 	impl_name: create_runtime_str!("root"),
 	authoring_version: 1,
-	spec_version: 69,
+	spec_version: 70,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
-	transaction_version: 13,
+	transaction_version: 14,
 	state_version: 0,
 };
 


### PR DESCRIPTION
# Release

**Release Name:** `10.70.0`

**Spec Version:** `70`

**Client Version:** `10.0.0`

## Key Changes:

This release introduces the following changes:

- Vortex rework onchain pallet changes

## PRs included:
- https://github.com/futureversecom/trn-seed/pull/934

---

## Client Changes:
- [ ] Yes
- [x] No

## Runtime Changes:
- [x] Yes
- [ ] No

## API Changes

### Storage Changes

#### Added

-  VortexDistribution: ConsiderCurrentBalance
-  VortexDistribution: DisableRedeem
-  VortexDistribution: EnableManualRewardInput
-  VortexDistribution: VtxVaultRedeemAssetList
-  VortexDistribution: TotalRewardPoints
-  VortexDistribution: TotalWorkPoints
-  VortexDistribution: VtxTotalSupply
-  VortexDistribution: VtxPrice
-  VortexDistribution: RewardPoints
-  VortexDistribution: WorkPoints
-  VortexDistribution: FeePotAssetsList
-  VortexDistribution: VtxVaultAssetsList
-  VortexDistribution: TotalNetworkReward
-  VortexDistribution: TotalBootstrapReward


#### Changed

- 

#### Removed

- VortexDistribution::VtxDistEras - no migration required as no data onchain
- VortexDistribution::StakeRewardsPoints - no migration required as no data onchain

### Extrinsic Changes

#### Added

- VortexDistribution::set_fee_pot_asset_balances
- VortexDistribution::set_vtx_vault_asset_balances
- VortexDistribution::set_vtx_total_supply
- VortexDistribution::register_reward_points
- VortexDistribution::register_work_points
- VortexDistribution::set_consider_current_balance
- VortexDistribution::set_disable_redeem
- VortexDistribution::set_enable_manual_reward_input

- VortexDistribution::set_vtx_vault_redeem_asset_list


#### Changed
- VortexDistribution::set_asset_prices
- VortexDistribution::trigger_vtx_distribution
- VortexDistribution::register_rewards
- VortexDistribution::redeem_tokens_from_vault

#### Removed

- VortexDistribution:: set_vtx_dist_eras


### Event Changes

#### Added

- VortexDistribution::SetFeePotAssetBalances
- VortexDistribution::SetVtxVaultAssetBalances
- VortexDistribution::VtxWorkPointRegistered
- VortexDistribution::VtxRewardPointRegistered
- VortexDistribution::SetVtxTotalSupply
- VortexDistribution::SetConsiderCurrentBalance
- VortexDistribution::SetDisableRedeem
- VortexDistribution::SetVtxVaultRedeemAssetList
- VortexDistribution::VtxRedeemed
- VortexDistribution::SetEnableManualRewardInput


#### Changed


#### Removed

- VortexDistribution::SetVtxDistEras

### Error Messages

#### Added

- VortexDistribution::ExceededMaxRewards
- VortexDistribution::AssetNotInFeePotList
- VortexDistribution::VortexPriceIsZero
- VortexDistribution::RootPriceIsZero
- VortexDistribution::VtxRedeemDisabled
- VortexDistribution::ManualRewardInputDisabled

#### Changed

-

#### Removed

- VortexDistribution::InvalidEndBlock

## Storage Migrations
