### PR TITLE
Remove fee pot asset check in price setter extrinsic

### DIFF
--- a/pallet/vortex-distribution/src/lib.rs
+++ b/pallet/vortex-distribution/src/lib.rs
@@ -1045,10 +1045,6 @@ pub mod pallet {
 					asset_id != &T::VtxAssetId::get(),
 					Error::<T>::AssetsShouldNotIncludeVtxAsset
 				);
-				ensure!(
-					Self::check_asset_exist_in_fee_pot_asset_list(id, asset_id),
-					Error::<T>::AssetNotInFeePotList
-				);
 				AssetPrices::<T>::insert(id, asset_id, price);
 			}
 
@@ -1316,19 +1312,6 @@ pub mod pallet {
 				},
 				None => Ok(None),
 			}
-		}
-
-		fn check_asset_exist_in_fee_pot_asset_list(
-			vtx_id: T::VtxDistIdentifier,
-			asset_id: &AssetId,
-		) -> bool {
-			for (id, _) in FeePotAssetsList::<T>::get(vtx_id).iter() {
-				if id == asset_id {
-					return true;
-				}
-			}
-
-			false
 		}
 	}
 }

--- a/pallet/vortex-distribution/src/lib.rs
+++ b/pallet/vortex-distribution/src/lib.rs
@@ -477,9 +477,6 @@ pub mod pallet {
 		/// out of max reward vecotor bound
 		ExceededMaxRewards,
 
-		/// asset (price set) is not in the fee pot assets list
-		AssetNotInFeePotList,
-
 		/// vortex price is zero
 		VortexPriceIsZero,
 


### PR DESCRIPTION
# Description

- There was an asset check inherited from the legacy code, which checks if an asset is already in the fee pot asset list during the execution of `set_asset_prices` extrinsic. This check can create a blocking scenario where the asset ID was transferred in a previous cycle and is in the vtx vault already, but not included in the current cycle. We still need to set a price for this asset if required as it would be used in Vtx price calculations.

## Context & Background

- _Add any relevant context or background information about the changes_

## Notes & Additional Information

- _Any additional notes, considerations, or explanations_

## Related Issues

- _Link any related issues_

---

<!-- This section will be used to automatically generate release notes -->
<!-- Please fill out relevant sections below based on your changes -->
<!-- Remove sections if there are no changes -->

# Release Notes

## Key Changes

## Type of Change

- [x] Runtime Changes
- [ ] Client Changes

## API Changes

### Error Messages

#### Added


#### Changed


#### Removed

- VortexDistribution::AssetNotInFeePotList

## Storage Migrations

---
