### PR TITLE
Replace Perbil with Perquintill for higher precision

### DIFF
--- a/pallet/vortex-distribution/src/lib.rs
+++ b/pallet/vortex-distribution/src/lib.rs
@@ -1234,9 +1234,20 @@ pub mod pallet {
 
 					// Add weight for writing VtxDistOrderbook
 					used_weight = used_weight.saturating_add(DbWeight::get().writes(1));
-					VtxDistOrderbook::<T>::mutate(id, account_id.clone(), |entry| {
-						*entry = (final_reward, entry.1);
-					});
+					log::info!(
+						"RewardCalculation - Account: {:?}, wkr: {:?}, rpr: {:?}, total r: {:?}",
+						account_id,
+						account_work_point_reward,
+						account_staker_reward,
+						final_reward
+					);
+					VtxDistOrderbook::<T>::mutate(
+						id,
+						account_id.clone(),
+						|entry: &mut (u128, bool)| {
+							*entry = (final_reward, entry.1);
+						},
+					);
 					count += 1;
 
 					// if no remaining_weight for the next entry iteration, brek

--- a/pallet/vortex-distribution/src/lib.rs
+++ b/pallet/vortex-distribution/src/lib.rs
@@ -1208,11 +1208,11 @@ pub mod pallet {
 				let total_network_reward = TotalNetworkReward::<T>::get(id);
 				let total_bootstrap_reward = TotalBootstrapReward::<T>::get(id);
 				// Ref -> https://docs.therootnetwork.com/intro/learn/tokenomics#how-are-rewards-distributed
-				const STAKER_REWARD_PORTION: Perquintill = Perquintill::from_percent(30); // 30% of network rewards
-				const WORK_POINTS_REWARD_PORTION: Perquintill = Perquintill::from_percent(70); // 70% of network rewards
+				// const STAKER_REWARD_PORTION: Perquintill = Perquintill::from_percent(30); // 30% of network rewards
+				// const WORK_POINTS_REWARD_PORTION: Perquintill = Perquintill::from_percent(70); // 70% of network rewards
 				let total_staker_pool = total_bootstrap_reward
-					.saturating_add(STAKER_REWARD_PORTION * total_network_reward); // bootstrap + 30% of network rewards
-				let total_workpoints_pool = WORK_POINTS_REWARD_PORTION * total_network_reward; // 70% of network rewards
+					.saturating_add(30.saturating_mul(total_network_reward).div(100)); // bootstrap + 30% of network rewards
+				let total_workpoints_pool = 70.saturating_mul(total_network_reward).div(100); // 70% of network rewards
 				let total_staker_points = TotalRewardPoints::<T>::get(id);
 				let total_work_points = TotalWorkPoints::<T>::get(id);
 
@@ -1237,13 +1237,17 @@ pub mod pallet {
 
 					// here both account_staker_points and total_staker_points are in same units. could be drops or standard units
 					// drops would give an opportunity to the accounts with smaller reward points than 1 standard unit.
-					let staker_point_portion =
-						Perquintill::from_rational(account_staker_points, total_staker_points);
-					let work_points_portion =
-						Perquintill::from_rational(account_work_points, total_work_points);
+					// let staker_point_portion =
+					// 	Perquintill::from_rational(account_staker_points, total_staker_points);
+					// let work_points_portion =
+					// 	Perquintill::from_rational(account_work_points, total_work_points);
 
-					let account_work_point_reward = work_points_portion * total_workpoints_pool;
-					let account_staker_reward = staker_point_portion * total_staker_pool;
+					let account_work_point_reward = account_work_points
+						.saturating_mul(total_workpoints_pool)
+						.div(total_work_points);
+					let account_staker_reward = account_staker_points
+						.saturating_mul(total_staker_pool)
+						.div(total_staker_points);
 					let final_reward =
 						account_work_point_reward.saturating_add(account_staker_reward); // This is in drops
 

--- a/pallet/vortex-distribution/src/lib.rs
+++ b/pallet/vortex-distribution/src/lib.rs
@@ -1235,7 +1235,7 @@ pub mod pallet {
 					// Add weight for writing VtxDistOrderbook
 					used_weight = used_weight.saturating_add(DbWeight::get().writes(1));
 					VtxDistOrderbook::<T>::mutate(id, account_id.clone(), |entry| {
-						*entry = (entry.0.saturating_add(final_reward), entry.1);
+						*entry = (final_reward, entry.1);
 					});
 					count += 1;
 

--- a/pallet/vortex-distribution/src/lib.rs
+++ b/pallet/vortex-distribution/src/lib.rs
@@ -1299,6 +1299,18 @@ pub mod pallet {
 						final_reward_float,
 						final_reward_float - final_reward as f64,
 					);
+
+					if final_reward == 0 {
+						log::info!(
+							"RewardCalculationZeros - Account: {:?}, wkp: {:?}, rp: {:?}, wkr: {:?}, rpr: {:?}",
+							account_id,
+							account_work_points,
+							account_staker_points,
+							account_work_point_reward,
+							account_staker_reward,
+						);
+					}
+
 					VtxDistOrderbook::<T>::mutate(
 						id,
 						account_id.clone(),

--- a/pallet/vortex-distribution/src/lib.rs
+++ b/pallet/vortex-distribution/src/lib.rs
@@ -835,7 +835,11 @@ pub mod pallet {
 								who: who.clone(),
 								amount: share,
 							});
-							// return Err(Error::<T>::VtxRewardPayoutFailed);
+							log::info!(
+								" VtxDistPayFailed - Account: {:?}, share: {:?}",
+								who,
+								share,
+							); // return Err(Error::<T>::VtxRewardPayoutFailed);
 						},
 					};
 

--- a/pallet/vortex-distribution/src/lib.rs
+++ b/pallet/vortex-distribution/src/lib.rs
@@ -63,7 +63,7 @@ use sp_runtime::{
 use sp_std::{convert::TryInto, prelude::*};
 
 pub const VTX_DIST_UNSIGNED_PRIORITY: TransactionPriority = TransactionPriority::MAX / 2;
-pub const PRECISION_MULTIPLIER: u128 = 10u128.pow(6);
+pub const PRECISION_MULTIPLIER: u128 = 10u128.pow(10);
 
 #[derive(
 	Clone, Copy, Encode, Decode, RuntimeDebug, PartialEq, PartialOrd, Eq, TypeInfo, MaxEncodedLen,
@@ -1161,15 +1161,14 @@ pub mod pallet {
 			//calculate total rewards
 			let vtx_decimal_factor: Balance =
 				10u128.pow(T::MultiCurrency::decimals(T::VtxAssetId::get()) as u32);
-			let precision_multiplier = 10u128.pow(6);
 			// multiply vault asset values by vtx_decimal_factor to get the value in drops for higher precision
 			let total_vortex_network_reward: Balance = fee_vault_asset_value
 				.saturating_mul(vtx_decimal_factor)
-				.saturating_mul(precision_multiplier)
+				.saturating_mul(PRECISION_MULTIPLIER)
 				.div(vortex_price);
 			let total_vortex_bootstrap: Balance = root_vault_root_value
 				.saturating_mul(vtx_decimal_factor)
-				.saturating_mul(precision_multiplier)
+				.saturating_mul(PRECISION_MULTIPLIER)
 				.div(vortex_price);
 			let total_vortex = total_vortex_network_reward.saturating_add(total_vortex_bootstrap); // in drops
 
@@ -1252,17 +1251,15 @@ pub mod pallet {
 					let account_work_point_reward = account_work_points
 						.saturating_mul(total_workpoints_pool)
 						.div(total_work_points);
-					let account_work_point_reward_float: f64 = account_work_points
-						.saturating_mul(total_workpoints_pool)
-						.div(total_work_points * PRECISION_MULTIPLIER)
-						as f64;
+					let account_work_point_reward_float: f64 =
+						account_work_points.saturating_mul(total_workpoints_pool) as f64
+							/ (total_work_points * PRECISION_MULTIPLIER) as f64;
 					let account_staker_reward = account_staker_points
 						.saturating_mul(total_staker_pool)
 						.div(total_staker_points);
-					let account_staker_reward_float: f64 = account_staker_points
-						.saturating_mul(total_staker_pool)
-						.div(total_staker_points * PRECISION_MULTIPLIER)
-						as f64;
+					let account_staker_reward_float: f64 =
+						account_staker_points.saturating_mul(total_staker_pool) as f64
+							/ (total_staker_points * crate::PRECISION_MULTIPLIER) as f64;
 					let final_reward = account_work_point_reward
 						.saturating_add(account_staker_reward)
 						.div(PRECISION_MULTIPLIER); // This is in drops

--- a/pallet/vortex-distribution/src/lib.rs
+++ b/pallet/vortex-distribution/src/lib.rs
@@ -58,7 +58,7 @@ use sp_runtime::{
 	traits::{
 		AccountIdConversion, AtLeast32BitUnsigned, CheckedAdd, One, Saturating, StaticLookup, Zero,
 	},
-	Perbill, RuntimeDebug,
+	Perquintill, RuntimeDebug,
 };
 use sp_std::{convert::TryInto, prelude::*};
 
@@ -1193,8 +1193,8 @@ pub mod pallet {
 				let total_network_reward = TotalNetworkReward::<T>::get(id);
 				let total_bootstrap_reward = TotalBootstrapReward::<T>::get(id);
 				// Ref -> https://docs.therootnetwork.com/intro/learn/tokenomics#how-are-rewards-distributed
-				const STAKER_REWARD_PORTION: Perbill = Perbill::from_percent(30); // 30% of network rewards
-				const WORK_POINTS_REWARD_PORTION: Perbill = Perbill::from_percent(70); // 70% of network rewards
+				const STAKER_REWARD_PORTION: Perquintill = Perquintill::from_percent(30); // 30% of network rewards
+				const WORK_POINTS_REWARD_PORTION: Perquintill = Perquintill::from_percent(70); // 70% of network rewards
 				let total_staker_pool = total_bootstrap_reward
 					.saturating_add(STAKER_REWARD_PORTION * total_network_reward); // bootstrap + 30% of network rewards
 				let total_workpoints_pool = WORK_POINTS_REWARD_PORTION * total_network_reward; // 70% of network rewards
@@ -1223,9 +1223,9 @@ pub mod pallet {
 					// here both account_staker_points and total_staker_points are in same units. could be drops or standard units
 					// drops would give an opportunity to the accounts with smaller reward points than 1 standard unit.
 					let staker_point_portion =
-						Perbill::from_rational(account_staker_points, total_staker_points);
+						Perquintill::from_rational(account_staker_points, total_staker_points);
 					let work_points_portion =
-						Perbill::from_rational(account_work_points, total_work_points);
+						Perquintill::from_rational(account_work_points, total_work_points);
 
 					let account_work_point_reward = work_points_portion * total_workpoints_pool;
 					let account_staker_reward = staker_point_portion * total_staker_pool;

--- a/pallet/vortex-distribution/src/lib.rs
+++ b/pallet/vortex-distribution/src/lib.rs
@@ -63,7 +63,7 @@ use sp_runtime::{
 use sp_std::{convert::TryInto, prelude::*};
 
 pub const VTX_DIST_UNSIGNED_PRIORITY: TransactionPriority = TransactionPriority::MAX / 2;
-pub const PRECISION_MULTIPLIER: u128 = 10u128.pow(10);
+pub const PRECISION_MULTIPLIER: u128 = 10u128.pow(6);
 
 #[derive(
 	Clone, Copy, Encode, Decode, RuntimeDebug, PartialEq, PartialOrd, Eq, TypeInfo, MaxEncodedLen,
@@ -1218,9 +1218,21 @@ pub mod pallet {
 				// const WORK_POINTS_REWARD_PORTION: Perquintill = Perquintill::from_percent(70); // 70% of network rewards
 				let total_staker_pool = total_bootstrap_reward
 					.saturating_add(30.saturating_mul(total_network_reward).div(100)); // bootstrap + 30% of network rewards
-				let total_workpoints_pool = 70.saturating_mul(total_network_reward).div(100); // 70% of network rewards
+				let total_workpoints_pool: u128 = 70.saturating_mul(total_network_reward).div(100); // 70% of network rewards
 				let total_staker_points = TotalRewardPoints::<T>::get(id);
 				let total_work_points = TotalWorkPoints::<T>::get(id);
+
+				let total_staker_pool_float: f64 =
+					total_bootstrap_reward as f64 + 0.3 * total_network_reward as f64;
+				let total_workpoints_pool_float: f64 = 0.7 * total_network_reward as f64; // 70% of network rewards
+
+				log::info!(
+						"RewardCalculationPools - total_staker_pool : {:?}, total_workpoints_pool: {:?}, total_staker_pool_float: {:?}, total_workpoints_pool_float r: {:?}",
+						total_staker_pool,
+						total_workpoints_pool,
+						total_staker_pool_float,
+						total_workpoints_pool_float,
+					);
 
 				// start key
 				let start_key = VtxRewardCalculationPivot::<T>::get(id);

--- a/pallet/vortex-distribution/src/lib.rs
+++ b/pallet/vortex-distribution/src/lib.rs
@@ -1252,21 +1252,39 @@ pub mod pallet {
 					let account_work_point_reward = account_work_points
 						.saturating_mul(total_workpoints_pool)
 						.div(total_work_points);
+					let account_work_point_reward_float: f64 = account_work_points
+						.saturating_mul(total_workpoints_pool)
+						.div(total_work_points * PRECISION_MULTIPLIER)
+						as f64;
 					let account_staker_reward = account_staker_points
 						.saturating_mul(total_staker_pool)
 						.div(total_staker_points);
+					let account_staker_reward_float: f64 = account_staker_points
+						.saturating_mul(total_staker_pool)
+						.div(total_staker_points * PRECISION_MULTIPLIER)
+						as f64;
 					let final_reward = account_work_point_reward
 						.saturating_add(account_staker_reward)
 						.div(PRECISION_MULTIPLIER); // This is in drops
+					let final_reward_float: f64 =
+						account_work_point_reward_float + account_staker_reward_float; // This is in drops
 
 					// Add weight for writing VtxDistOrderbook
 					used_weight = used_weight.saturating_add(DbWeight::get().writes(1));
 					log::info!(
-						"RewardCalculation - Account: {:?}, wkr: {:?}, rpr: {:?}, total r: {:?}",
+						"RewardCalculationInt - Account: {:?}, wkr: {:?}, rpr: {:?}, total r: {:?}",
 						account_id,
 						account_work_point_reward,
 						account_staker_reward,
 						final_reward
+					);
+					log::info!(
+						"RewardCalculationFloat - Account: {:?}, wkr: {:?}, rpr: {:?}, total r: {:?}, diff: {:?}",
+						account_id,
+						account_work_point_reward_float,
+						account_staker_reward_float,
+						final_reward_float,
+						final_reward_float - final_reward as f64,
 					);
 					VtxDistOrderbook::<T>::mutate(
 						id,

--- a/pallet/vortex-distribution/src/lib.rs
+++ b/pallet/vortex-distribution/src/lib.rs
@@ -335,6 +335,9 @@ pub mod pallet {
 		/// Distribution paid out
 		VtxDistPaidOut { id: T::VtxDistIdentifier, who: T::AccountId, amount: Balance },
 
+		/// Distribution payment failed
+		VtxDistPayFailed { id: T::VtxDistIdentifier, who: T::AccountId, amount: Balance },
+
 		/// Distribution started
 		VtxDistStarted { id: T::VtxDistIdentifier },
 
@@ -487,6 +490,9 @@ pub mod pallet {
 
 		/// Manual reward input is disabled
 		ManualRewardInputDisabled,
+
+		/// Vtx reward payout failed
+		VtxRewardPayoutFailed,
 	}
 
 	#[pallet::call]
@@ -805,24 +811,33 @@ pub mod pallet {
 					}
 
 					let share = entry.0;
-					let transfer_result = Self::safe_transfer(
+					match Self::safe_transfer(
 						T::VtxAssetId::get(),
 						&vtx_held_account,
 						&who,
 						share,
 						false,
-					);
+					) {
+						Ok(_) => {
+							Self::deposit_event(Event::VtxDistPaidOut {
+								id,
+								who: who.clone(),
+								amount: share,
+							});
+							VtxDistOrderbook::<T>::mutate(id, who.clone(), |entry| {
+								*entry = (entry.0, true);
+							});
+						},
+						Err(_) => {
+							Self::deposit_event(Event::VtxDistPayFailed {
+								id,
+								who: who.clone(),
+								amount: share,
+							});
+							// return Err(Error::<T>::VtxRewardPayoutFailed);
+						},
+					};
 
-					if transfer_result.is_ok() {
-						Self::deposit_event(Event::VtxDistPaidOut {
-							id,
-							who: who.clone(),
-							amount: share,
-						});
-					}
-					VtxDistOrderbook::<T>::mutate(id, who.clone(), |entry| {
-						*entry = (entry.0, true);
-					});
 					count += 1;
 					if count > T::PayoutBatchSize::get() {
 						break;

--- a/pallet/vortex-distribution/src/mock.rs
+++ b/pallet/vortex-distribution/src/mock.rs
@@ -14,6 +14,7 @@
 // You may obtain a copy of the License at the root of this project source code
 
 use crate as pallet_vortex_distribution;
+use crate::PRECISION_MULTIPLIER;
 use frame_support::traits::{ConstU32, Hooks};
 use seed_pallet_common::test_prelude::*;
 use sp_runtime::traits::Zero;
@@ -72,10 +73,15 @@ pub fn calculate_vtx(
 
 	// calculate in drops for higher precision
 	let vtx_decimal_factor: Balance = 10u128.pow(6).into();
-	let total_vortex_network_reward =
-		fee_vault_asset_value.saturating_mul(vtx_decimal_factor).div(vtx_price);
-	let total_vortex_bootstrap =
-		bootstrap_asset_value.saturating_mul(vtx_decimal_factor).div(vtx_price);
+
+	let total_vortex_network_reward = fee_vault_asset_value
+		.saturating_mul(vtx_decimal_factor)
+		.saturating_mul(PRECISION_MULTIPLIER)
+		.div(vtx_price);
+	let total_vortex_bootstrap = bootstrap_asset_value
+		.saturating_mul(vtx_decimal_factor)
+		.saturating_mul(PRECISION_MULTIPLIER)
+		.div(vtx_price);
 	let total_vortex = total_vortex_network_reward.saturating_add(total_vortex_bootstrap);
 
 	(total_vortex_network_reward, total_vortex_bootstrap, total_vortex)
@@ -207,7 +213,7 @@ impl crate::Config for Test {
 	type MultiCurrency = AssetsExt;
 	type HistoryDepth = HistoryDepth;
 	type MaxAssetPrices = ConstU32<1000>;
-	type MaxRewards = ConstU32<2_100>;
+	type MaxRewards = ConstU32<4_100>;
 	type MaxStringLength = ConstU32<1000>;
 }
 

--- a/pallet/vortex-distribution/src/tests.rs
+++ b/pallet/vortex-distribution/src/tests.rs
@@ -21,6 +21,7 @@ use crate::mock::{
 };
 use hex_literal::hex;
 use seed_pallet_common::test_prelude::*;
+use sp_runtime::PerThing;
 
 #[test]
 fn set_admin_works_with_root_account() {
@@ -847,12 +848,12 @@ fn trigger_vtx_distribution_works() {
 			assert_eq!(TotalBootstrapReward::<Test>::get(vortex_dist_id), total_vortex_bootstrap);
 
 			// check bob got the vortex reward registered
-			let staker_pool =
-				total_vortex_bootstrap + (Perbill::from_percent(30) * total_vortex_network_reward);
-			let workpoint_pool = Perbill::from_percent(70) * total_vortex_network_reward;
+			let staker_pool = total_vortex_bootstrap
+				+ (Perquintill::from_percent(30) * total_vortex_network_reward);
+			let workpoint_pool = Perquintill::from_percent(70) * total_vortex_network_reward;
 			let bob_staker_point_portion =
-				Perbill::from_rational(100_000_u128, 100_000_u128 + 100_000_u128);
-			let bob_work_points_portion = Perbill::from_rational(10_u128, 10_u128 + 10_u128);
+				Perquintill::from_rational(100_000_u128, 100_000_u128 + 100_000_u128);
+			let bob_work_points_portion = Perquintill::from_rational(10_u128, 10_u128 + 10_u128);
 			let bob_vtx_reward_calculated = (bob_staker_point_portion * staker_pool)
 				+ (bob_work_points_portion * workpoint_pool);
 			assert_eq!(
@@ -1077,12 +1078,12 @@ fn trigger_vtx_distribution_should_fail_if_already_triggered() {
 			assert_eq!(TotalBootstrapReward::<Test>::get(vortex_dist_id), total_vortex_bootstrap);
 
 			// check bob got the vortex reward registered
-			let staker_pool =
-				total_vortex_bootstrap + (Perbill::from_percent(30) * total_vortex_network_reward);
-			let workpoint_pool = Perbill::from_percent(70) * total_vortex_network_reward;
+			let staker_pool = total_vortex_bootstrap
+				+ (Perquintill::from_percent(30) * total_vortex_network_reward);
+			let workpoint_pool = Perquintill::from_percent(70) * total_vortex_network_reward;
 			let bob_staker_point_portion =
-				Perbill::from_rational(100_000_u128, 100_000_u128 + 100_000_u128);
-			let bob_work_points_portion = Perbill::from_rational(10_u128, 10_u128 + 10_u128);
+				Perquintill::from_rational(100_000_u128, 100_000_u128 + 100_000_u128);
+			let bob_work_points_portion = Perquintill::from_rational(10_u128, 10_u128 + 10_u128);
 			let bob_vtx_reward_calculated = (bob_staker_point_portion * staker_pool)
 				+ (bob_work_points_portion * workpoint_pool);
 			assert_eq!(
@@ -1752,12 +1753,12 @@ fn pay_unsigned_with_multiple_payout_blocks() {
 			println!("total_vortex_bootstrap: {:?}", total_vortex_bootstrap);
 
 			// check bob got the vortex reward registered
-			let staker_pool =
-				total_vortex_bootstrap + (Perbill::from_percent(30) * total_vortex_network_reward);
-			let workpoint_pool = Perbill::from_percent(70) * total_vortex_network_reward;
+			let staker_pool = total_vortex_bootstrap
+				+ (Perquintill::from_percent(30) * total_vortex_network_reward);
+			let workpoint_pool = Perquintill::from_percent(70) * total_vortex_network_reward;
 			let bob_staker_point_portion =
-				Perbill::from_rational(100_000_u128, total_reward_points);
-			let bob_work_points_portion = Perbill::from_rational(10_u128, total_work_points);
+				Perquintill::from_rational(100_000_u128, total_reward_points);
+			let bob_work_points_portion = Perquintill::from_rational(10_u128, total_work_points);
 			println!("bob_staker_point_portion: {:?}", bob_staker_point_portion);
 			println!("bob_work_points_portion: {:?}", bob_work_points_portion);
 			println!("staker_pool: {:?}", staker_pool);
@@ -2194,15 +2195,15 @@ fn print_reward_details_for_account() {
 
 	// check vortex reward for the account
 	let staker_pool =
-		total_vortex_bootstrap + (Perbill::from_percent(30) * total_vortex_network_reward);
-	let workpoint_pool = Perbill::from_percent(70) * total_vortex_network_reward;
+		total_vortex_bootstrap + (Perquintill::from_percent(30) * total_vortex_network_reward);
+	let workpoint_pool = Perquintill::from_percent(70) * total_vortex_network_reward;
 	println!("staker_pool: {:?}", staker_pool);
 	println!("workpoint_pool: {:?}", workpoint_pool);
 
 	let account_staker_point_portion =
-		Perbill::from_rational(account_staker_reward_points, total_staker_reward_points);
+		Perquintill::from_rational(account_staker_reward_points, total_staker_reward_points);
 	let account_work_points_portion =
-		Perbill::from_rational(account_worker_points, total_worker_points);
+		Perquintill::from_rational(account_worker_points, total_worker_points);
 	println!("account_staker_point_portion: {:?}", account_staker_point_portion);
 	println!("account_work_points_portion: {:?}", account_work_points_portion);
 
@@ -2580,7 +2581,7 @@ fn set_enable_manual_reward_input_can_be_used_for_legacy_flow_before_trigger() {
 // vortex price should be 1  if vtx_existing_supply is 0
 
 #[test]
-fn vtx_price_calculation_cuycle_5() {
+fn vtx_price_calculation_cycle_5() {
 	let alice: AccountId = create_account(1);
 	let bob: AccountId = create_account(2);
 	let charlie: AccountId = create_account(3);
@@ -2826,12 +2827,12 @@ fn vtx_price_calculation_cuycle_5() {
 			assert_eq!(TotalBootstrapReward::<Test>::get(vortex_dist_id), total_vortex_bootstrap);
 
 			// check bob got the vortex reward registered
-			let staker_pool =
-				total_vortex_bootstrap + (Perbill::from_percent(30) * total_vortex_network_reward);
-			let workpoint_pool = Perbill::from_percent(70) * total_vortex_network_reward;
+			let staker_pool = total_vortex_bootstrap
+				+ (Perquintill::from_percent(30) * total_vortex_network_reward);
+			let workpoint_pool = Perquintill::from_percent(70) * total_vortex_network_reward;
 			let bob_staker_point_portion =
-				Perbill::from_rational(100_000_u128, 100_000_u128 + 100_000_u128);
-			let bob_work_points_portion = Perbill::from_rational(10_u128, 10_u128 + 10_u128);
+				Perquintill::from_rational(100_000_u128, 100_000_u128 + 100_000_u128);
+			let bob_work_points_portion = Perquintill::from_rational(10_u128, 10_u128 + 10_u128);
 			let bob_vtx_reward_calculated = (bob_staker_point_portion * staker_pool)
 				+ (bob_work_points_portion * workpoint_pool);
 			assert_eq!(
@@ -3071,12 +3072,12 @@ fn trigger_vtx_distribution_with_high_vtx_price() {
 			assert_eq!(TotalBootstrapReward::<Test>::get(vortex_dist_id), 166666);
 
 			// check bob got the vortex reward registered
-			let staker_pool =
-				total_vortex_bootstrap + (Perbill::from_percent(30) * total_vortex_network_reward);
-			let workpoint_pool = Perbill::from_percent(70) * total_vortex_network_reward;
+			let staker_pool = total_vortex_bootstrap
+				+ (Perquintill::from_percent(30) * total_vortex_network_reward);
+			let workpoint_pool = Perquintill::from_percent(70) * total_vortex_network_reward;
 			let bob_staker_point_portion =
-				Perbill::from_rational(100_000_u128, 100_000_u128 + 100_000_u128);
-			let bob_work_points_portion = Perbill::from_rational(10_u128, 10_u128 + 10_u128);
+				Perquintill::from_rational(100_000_u128, 100_000_u128 + 100_000_u128);
+			let bob_work_points_portion = Perquintill::from_rational(10_u128, 10_u128 + 10_u128);
 			let bob_vtx_reward_calculated = (bob_staker_point_portion * staker_pool)
 				+ (bob_work_points_portion * workpoint_pool);
 			assert_eq!(
@@ -3084,4 +3085,258 @@ fn trigger_vtx_distribution_with_high_vtx_price() {
 				(bob_vtx_reward_calculated, false)
 			);
 		});
+}
+
+#[test]
+fn vtx_price_calculation_cycle_5_real_data() {
+	let alice: AccountId = create_account(1);
+	let bob: AccountId = create_account(2);
+	let charlie: AccountId = create_account(3);
+
+	// asset ids
+	let asto_asset_id = 4_196;
+	let sylo_asset_id = 2_148;
+	let eth_asset_id = 1_124;
+	let xrp_asset_id = 2;
+	let root_asset_id = 1;
+	let vtx_asset_id = <Test as crate::Config>::VtxAssetId::get();
+	// vortex vault pre asset balances - same as cycle 5
+	let vortex_vault = Vortex::get_vtx_vault_account();
+	let root_balance_in_vtx_vault = 12768121398776_u128;
+	let asto_balance_in_vtx_vault = 3319193139068424549_u128;
+	let xrp_balance_in_vtx_vault = 33360272058_u128;
+	let sylo_balance_in_vtx_vault = 1598213439551632365_u128;
+	let eth_balance_in_vtx_vault = 459527286806489_u128;
+	let vtx_total_supply = 870428149751_u128;
+
+	// fee pot asset balance
+	let fee_vault = Vortex::get_fee_vault_account();
+	let asto_fee_pot_balance = 6_750_001_162_780_848_574;
+	let xrp_fee_pot_balance = 14_694_106_335;
+	let root_fee_pot_balance = 18_631_164_600;
+
+	let root_vault = Vortex::get_root_vault_account();
+	let bootstrap_root = 17_057_331_103_329;
+
+	// prices should be multiplied by the usd factor 10**6
+	let root_price = (0.01614 * 1000000.00) as u128;
+	let xrp_price = (2.4613 * 1000000.00) as u128;
+	let sylo_price = (0.0006042 * 1000000.00) as u128;
+	let asto_price = (0.01746 * 1000000.00) as u128;
+	let eth_price = (2681.04 * 1000000.00) as u128;
+
+	TestExt::default()
+		.with_balances(&[
+			(alice, 2_000_000),
+			(vortex_vault, root_balance_in_vtx_vault),
+			(fee_vault, root_fee_pot_balance),
+			(root_vault, bootstrap_root),
+		])
+		.with_asset_decimals(root_asset_id, "ROOT", 6, &[(alice, 1_000_000)]) // note this is just to create the ROOT asset in the system
+		.with_asset_decimals(
+			xrp_asset_id,
+			"XRP",
+			6,
+			&[
+				(alice, 1_000_000),
+				(vortex_vault, xrp_balance_in_vtx_vault),
+				(fee_vault, xrp_fee_pot_balance),
+			],
+		)
+		.with_asset_decimals(
+			asto_asset_id,
+			"ASTO",
+			18,
+			&[
+				(alice, 1_000_000),
+				(vortex_vault, asto_balance_in_vtx_vault),
+				(fee_vault, asto_fee_pot_balance),
+			],
+		)
+		.with_asset_decimals(
+			sylo_asset_id,
+			"SYLO",
+			18,
+			&[(alice, 5), (vortex_vault, sylo_balance_in_vtx_vault)],
+		)
+		.with_asset_decimals(
+			eth_asset_id,
+			"ETH",
+			18,
+			&[(alice, 1_000_000), (vortex_vault, eth_balance_in_vtx_vault)],
+		)
+		.with_asset_decimals(vtx_asset_id, "VTX", 6, &[(alice, vtx_total_supply)])
+		.build()
+		.execute_with(|| {
+			let vortex_dist_id = NextVortexId::<Test>::get();
+
+			// check accounts has correct balances
+			assert_eq!(AssetsExt::balance(root_asset_id, &vortex_vault), root_balance_in_vtx_vault);
+			assert_eq!(AssetsExt::balance(xrp_asset_id, &vortex_vault), xrp_balance_in_vtx_vault);
+			assert_eq!(AssetsExt::balance(asto_asset_id, &vortex_vault), asto_balance_in_vtx_vault);
+			assert_eq!(AssetsExt::balance(sylo_asset_id, &vortex_vault), sylo_balance_in_vtx_vault);
+			assert_eq!(AssetsExt::balance(eth_asset_id, &vortex_vault), eth_balance_in_vtx_vault);
+			assert_eq!(AssetsExt::balance(asto_asset_id, &fee_vault), asto_fee_pot_balance);
+			assert_eq!(AssetsExt::balance(xrp_asset_id, &fee_vault), xrp_fee_pot_balance);
+			assert_eq!(AssetsExt::balance(root_asset_id, &fee_vault), root_fee_pot_balance);
+			assert_eq!(AssetsExt::balance(root_asset_id, &root_vault), bootstrap_root);
+			// create vortex distribution
+			assert_ok!(Vortex::create_vtx_dist(Origin::root()));
+
+			// set vortex vault pre asset balances
+			let vtx_vault_asset_balances = vec![
+				(root_asset_id, root_balance_in_vtx_vault),
+				(xrp_asset_id, xrp_balance_in_vtx_vault),
+				(asto_asset_id, asto_balance_in_vtx_vault),
+				(sylo_asset_id, sylo_balance_in_vtx_vault),
+				(eth_asset_id, eth_balance_in_vtx_vault),
+			];
+			assert_ok!(Vortex::set_vtx_vault_asset_balances(
+				Origin::root(),
+				vortex_dist_id,
+				BoundedVec::try_from(vtx_vault_asset_balances.clone()).unwrap(),
+			));
+			// set Vtx current supply
+			assert_ok!(Vortex::set_vtx_total_supply(
+				Origin::root(),
+				vortex_dist_id,
+				vtx_total_supply,
+			));
+
+			// set fee pot asset balances
+			let fee_pot_asset_balances = vec![
+				(asto_asset_id, asto_fee_pot_balance),
+				(xrp_asset_id, xrp_fee_pot_balance),
+				(root_asset_id, root_fee_pot_balance),
+			];
+			assert_ok!(Vortex::set_fee_pot_asset_balances(
+				Origin::root(),
+				vortex_dist_id,
+				BoundedVec::try_from(fee_pot_asset_balances.clone()).unwrap(),
+			));
+
+			//set asset price
+			let asset_prices = vec![
+				(root_asset_id, root_price),
+				(xrp_asset_id, xrp_price),
+				(asto_asset_id, asto_price),
+				(sylo_asset_id, sylo_price),
+				(eth_asset_id, eth_price),
+			];
+			assert_ok!(Vortex::set_asset_prices(
+				Origin::root(),
+				vortex_dist_id,
+				BoundedVec::try_from(asset_prices.clone()).unwrap(),
+			));
+
+			// register reward and work points
+			let reward_points =
+				BoundedVec::try_from(vec![(bob, 24600), (charlie, 17057331103329 - 24600)])
+					.unwrap();
+			let work_points = BoundedVec::try_from(vec![(charlie, 39180127080137)]).unwrap();
+			assert_ok!(Vortex::register_reward_points(
+				Origin::root(),
+				vortex_dist_id,
+				reward_points
+			));
+			assert_ok!(Vortex::register_work_points(Origin::root(), vortex_dist_id, work_points));
+
+			// trigger vortex distribution and do the preparations for distribution
+			assert_ok!(Vortex::trigger_vtx_distribution(Origin::root(), vortex_dist_id));
+			// Check that the correct event was emitted.
+			System::assert_last_event(MockEvent::Vortex(crate::Event::VtxDistributionTriggering {
+				id: vortex_dist_id,
+			}));
+			// run a few blocks to move the Vtx status from Triggering to Triggered
+			for i in 2_u32..4 {
+				System::set_block_number(i.into());
+				Vortex::on_idle(i.into(), Weight::from_all(1_000_000_000_000_u64));
+			}
+			System::assert_last_event(MockEvent::Vortex(crate::Event::VtxDistributionTriggered {
+				id: vortex_dist_id,
+			}));
+
+			// check balances have been transferred to vtx vault account
+			// check fee pot and bootstrap root account has correct balances
+			assert_eq!(AssetsExt::balance(root_asset_id, &root_vault), 0);
+			assert_eq!(AssetsExt::balance(xrp_asset_id, &fee_vault), 0);
+			assert_eq!(AssetsExt::balance(eth_asset_id, &fee_vault), 0);
+			assert_eq!(AssetsExt::balance(asto_asset_id, &fee_vault), 0);
+			assert_eq!(AssetsExt::balance(sylo_asset_id, &fee_vault), 0);
+			assert_eq!(
+				AssetsExt::balance(root_asset_id, &vortex_vault),
+				root_balance_in_vtx_vault + bootstrap_root + root_fee_pot_balance
+			);
+			assert_eq!(
+				AssetsExt::balance(xrp_asset_id, &vortex_vault),
+				xrp_balance_in_vtx_vault + xrp_fee_pot_balance
+			);
+			assert_eq!(AssetsExt::balance(eth_asset_id, &vortex_vault), eth_balance_in_vtx_vault);
+			assert_eq!(
+				AssetsExt::balance(asto_asset_id, &vortex_vault),
+				asto_balance_in_vtx_vault + asto_fee_pot_balance
+			);
+			assert_eq!(AssetsExt::balance(sylo_asset_id, &vortex_vault), sylo_balance_in_vtx_vault);
+			// check VtxPrice tally
+			let vtx_vault_asset_balances_with_decimals = vec![
+				(root_asset_id, root_balance_in_vtx_vault, 6),
+				(xrp_asset_id, xrp_balance_in_vtx_vault, 6),
+				(asto_asset_id, asto_balance_in_vtx_vault, 18),
+				(sylo_asset_id, sylo_balance_in_vtx_vault, 18),
+				(eth_asset_id, eth_balance_in_vtx_vault, 18),
+			];
+			let vtx_price_calculted = calculate_vtx_price(
+				&vtx_vault_asset_balances_with_decimals,
+				&asset_prices,
+				vtx_total_supply,
+			);
+			println!("vtx_price_calculted: {}", vtx_price_calculted);
+			assert_eq!(VtxPrice::<Test>::get(vortex_dist_id), vtx_price_calculted);
+			// check vtx amounts tally
+			let fee_pot_asset_balances_with_decimals = vec![
+				(root_asset_id, root_fee_pot_balance, 6),
+				(xrp_asset_id, xrp_fee_pot_balance, 6),
+				(asto_asset_id, asto_fee_pot_balance, 18),
+			];
+			let (total_vortex_network_reward, total_vortex_bootstrap, total_vortex) = calculate_vtx(
+				&fee_pot_asset_balances_with_decimals,
+				&asset_prices,
+				bootstrap_root,
+				root_price,
+				vtx_price_calculted,
+			);
+			assert_eq!(TotalVortex::<Test>::get(vortex_dist_id), total_vortex);
+			assert_eq!(
+				TotalNetworkReward::<Test>::get(vortex_dist_id),
+				total_vortex_network_reward
+			);
+			assert_eq!(TotalBootstrapReward::<Test>::get(vortex_dist_id), total_vortex_bootstrap);
+
+			// check bob got the vortex reward registered
+			let staker_pool = total_vortex_bootstrap
+				+ (Perquintill::from_percent(30) * total_vortex_network_reward);
+			let workpoint_pool = Perquintill::from_percent(70) * total_vortex_network_reward;
+			let bob_staker_point_portion =
+				Perquintill::from_rational(24600_u128, 17_057_331_103_329);
+			let bob_work_points_portion = Perquintill::from_rational(0_u128, 39180127080137_u128);
+			let bob_staker_reward_calculated = bob_staker_point_portion * staker_pool;
+			let bob_work_points_reward_calculated = bob_work_points_portion * workpoint_pool;
+			let bob_vtx_reward_calculated =
+				bob_staker_reward_calculated + bob_work_points_reward_calculated;
+			assert_eq!(
+				VtxDistOrderbook::<Test>::get(vortex_dist_id, bob),
+				(bob_vtx_reward_calculated, false)
+			);
+		});
+}
+
+#[test]
+fn test_precision_in_perwuintill_from_rational() {
+	let account_staker_points = 1_u128;
+	let total_staker_points = 17057331103329_u128;
+
+	let staker_point_portion =
+		Perquintill::from_rational(account_staker_points, total_staker_points);
+
+	assert_eq!(staker_point_portion, Perquintill::from_float(0.000000000000058625_f64));
 }


### PR DESCRIPTION
# Description

- `Perbil` precision is not enough if an account has a lower reward/work point value when calculating the account reward portion. Hence, changing to use  `Perquintill`

## Context & Background

- for example, `24600/ 17057331103329 = 0.000000001442195`, but perbill stores it as `0.000000001`, losing a significant portion. if used Perquintill, it stores as  `0.000000001442195138`
- Also it can represent the minimum value given the current max value. i.e `1/ 17057331103329 = 0.00000000000005862581865`. Perquintill represents it as `0.000000000000058625`

## Notes & Additional Information

- _Any additional notes, considerations, or explanations_

## Related Issues

- _Link any related issues_

---

<!-- This section will be used to automatically generate release notes -->
<!-- Please fill out relevant sections below based on your changes -->
<!-- Remove sections if there are no changes -->

# Release Notes

## Key Changes

## Type of Change

- [x] Runtime Changes
- [ ] Client Changes

## API Changes
