### PR TITLE
Release 11.79.0

### DIFF
--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -152,7 +152,7 @@ mod tests;
 /// Currency implementation mapped to XRP
 pub type XrpCurrency = pallet_assets_ext::AssetCurrency<Runtime, XrpAssetId>;
 
-/// This runtime version.
+/// The runtime version information.
 #[sp_version::runtime_version]
 pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("root"),


### PR DESCRIPTION
# Release

**Release Name:** `11.79.0`

**Spec Version:** `79`

**Client Version:** `11.0.0`

## Key Changes:

This release adds a multi block migration for the NFT pallet to migrate token ownership information

## PRs included:
- https://github.com/futureversecom/trn-seed/pull/921

---

## Client Changes:
- [ ] Yes
- [x] No

## Runtime Changes:
- [x] Yes
- [ ] No

## API Changes

### Storage Changes

#### Added

- Nft: TokenInfo
- Nft: OwnedTokens
- Nft: NextIssuanceId
- Sft: NextIssuanceId

#### Changed

- Nft: CollectionInfo
- Nft: PendingIssuances
- Sft: PendingIssuances

#### Removed

- Nft: TokenLocks
- Nft: TokenUtilityFlags

## Storage Migrations

#### Added

- Nft Multiblock migration: migrate token ownership
- Nft migration: remove PendingIssuances
- Sft Migration: remove PendingIssuances