### PR TITLE
Release/11.81.0

### DIFF
--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -160,7 +160,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("root"),
 	impl_name: create_runtime_str!("root"),
 	authoring_version: 1,
-	spec_version: 80,
+	spec_version: 81,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 19,


### PR DESCRIPTION
# Release

**Release Name:** `11.81.0`

**Spec Version:** `81`

**Client Version:** `11.0.0`

## Key Changes:

- Addresses the feedback given by the Red4Sec audit to improve the Liquidity Pools pallet
- Removes Multiblock, Fee control and Attribution migrations

## PRs included:
- https://github.com/futureversecom/trn-seed/pull/967
- https://github.com/futureversecom/trn-seed/pull/965

---

## Client Changes:
- [ ] Yes
- [x] No

## Runtime Changes:
- [x] Yes
- [ ] No

## API Changes

### Storage Changes

#### Added

- LiquidityPools: ProcessedPoolPivot

### Extrinsic Changes

#### Changed

- LiquidityPools: exit_pool, allow exit on closed pools
- LiquidityPools: close_pool, don't send staked tokens to creator

### Error Messages

#### Added

- LiquidityPools: PoolAlreadyClosed
- LiquidityPools: CannotExitPool
- LiquidityPools: RewardCalculationOverflow

## Storage Migrations

#### Removed

- NFT: Multiblock Migration
- Feecontrol: Data migration
- Attributions: Count Migration
---