### PR TITLE
Feat/marketplace offer expiry

### DIFF
--- a/evm-precompiles/marketplace/src/lib.rs
+++ b/evm-precompiles/marketplace/src/lib.rs
@@ -985,6 +985,7 @@ where
 			amount,
 			asset_id,
 			Some(marketplace_id),
+			None,
 		)
 		.map_err(|e| {
 			revert(alloc::format!("Marketplace: Dispatched call failed with error: {:?}", e))

--- a/pallet/marketplace/src/benchmarking.rs
+++ b/pallet/marketplace/src/benchmarking.rs
@@ -357,6 +357,15 @@ benchmarks! {
 		assert!(Offers::<T>::get(offer_id).is_none());
 	}
 
+	remove_offer {
+		let collection_id = build_collection::<T>(None);
+		let offer_id = offer_builder::<T>(collection_id);
+	}: _(origin::<T>(&account::<T>("Alice")), offer_id)
+	verify {
+		assert_eq!(NextOfferId::<T>::get(), offer_id + 1);
+		assert!(Offers::<T>::get(offer_id).is_none());
+	}
+
 	set_fee_to {
 		let fee_account = account::<T>("Alice");
 	}: _(RawOrigin::Root, Some(fee_account))

--- a/pallet/marketplace/src/lib.rs
+++ b/pallet/marketplace/src/lib.rs
@@ -268,6 +268,8 @@ pub mod pallet {
 			amount: Balance,
 			asset_id: AssetId,
 		},
+		/// An offer has been removed by the listing owner
+		OfferRemove { offer_id: OfferId, marketplace_id: Option<MarketplaceId>, token_id: TokenId },
 		/// The network fee receiver address has been updated
 		FeeToSet { account: Option<T::AccountId> },
 	}
@@ -590,9 +592,19 @@ pub mod pallet {
 			Self::do_accept_offer(who, offer_id)
 		}
 
+		/// Removes an offer on a token
+		/// Caller must be token owner
+		#[pallet::call_index(13)]
+		#[pallet::weight(T::WeightInfo::remove_offer())]
+		#[transactional]
+		pub fn remove_offer(origin: OriginFor<T>, offer_id: OfferId) -> DispatchResult {
+			let who = ensure_signed(origin)?;
+			Self::do_remove_offer(who, offer_id)
+		}
+
 		/// Set the `FeeTo` account
 		/// This operation requires root access
-		#[pallet::call_index(13)]
+		#[pallet::call_index(14)]
 		#[pallet::weight(T::WeightInfo::set_fee_to())]
 		pub fn set_fee_to(origin: OriginFor<T>, fee_to: Option<T::AccountId>) -> DispatchResult {
 			ensure_root(origin)?;

--- a/pallet/marketplace/src/lib.rs
+++ b/pallet/marketplace/src/lib.rs
@@ -269,6 +269,7 @@ pub mod pallet {
 			asset_id: AssetId,
 			marketplace_id: Option<MarketplaceId>,
 			buyer: T::AccountId,
+			close: BlockNumberFor<T>,
 		},
 		/// An offer has been cancelled
 		OfferCancel { offer_id: OfferId, marketplace_id: Option<MarketplaceId>, token_id: TokenId },

--- a/pallet/marketplace/src/mock.rs
+++ b/pallet/marketplace/src/mock.rs
@@ -39,6 +39,7 @@ impl_pallet_sft_config!(Test);
 parameter_types! {
 	pub const MarketplacePalletId: PalletId = PalletId(*b"marketpl");
 	pub const DefaultListingDuration: u64 = 100;
+	pub const DefaultOfferDuration: u64 = 1000;
 	pub const MaxOffers: u32 = 10;
 	pub const MaxTokensPerListing: u32 = 100;
 	pub const MaxListingsPerMultiBuy: u32 = 100;
@@ -49,6 +50,7 @@ parameter_types! {
 impl crate::Config for Test {
 	type RuntimeCall = RuntimeCall;
 	type DefaultListingDuration = DefaultListingDuration;
+	type DefaultOfferDuration = DefaultOfferDuration;
 	type RuntimeEvent = RuntimeEvent;
 	type DefaultFeeTo = DefaultFeeTo;
 	type MultiCurrency = AssetsExt;

--- a/pallet/marketplace/src/mock.rs
+++ b/pallet/marketplace/src/mock.rs
@@ -41,6 +41,7 @@ parameter_types! {
 	pub const DefaultListingDuration: u64 = 100;
 	pub const DefaultOfferDuration: u64 = 1000;
 	pub const MaxOffers: u32 = 10;
+	pub const MaxRemovableOffers: u32 = 10;
 	pub const MaxTokensPerListing: u32 = 100;
 	pub const MaxListingsPerMultiBuy: u32 = 100;
 	pub const DefaultFeeTo: Option<PalletId> = Some(FeePotId::get());
@@ -62,4 +63,5 @@ impl crate::Config for Test {
 	type MaxTokensPerListing = MaxTokensPerListing;
 	type MaxListingsPerMultiBuy = MaxListingsPerMultiBuy;
 	type MaxOffers = MaxOffers;
+	type MaxRemovableOffers = MaxRemovableOffers;
 }

--- a/pallet/marketplace/src/tests.rs
+++ b/pallet/marketplace/src/tests.rs
@@ -15,9 +15,9 @@
 
 use super::*;
 use crate::mock::{
-	AssetsExt, DefaultListingDuration, FeePotId, Marketplace, MarketplaceNetworkFeePercentage,
-	MarketplacePalletId, MaxTokensPerListing, NativeAssetId, Nft, RuntimeEvent as MockEvent, Sft,
-	System, Test, TransferLimit,
+	AssetsExt, DefaultListingDuration, DefaultOfferDuration, FeePotId, Marketplace,
+	MarketplaceNetworkFeePercentage, MarketplacePalletId, MaxTokensPerListing, NativeAssetId, Nft,
+	RuntimeEvent as MockEvent, Sft, System, Test, TransferLimit,
 };
 use core::ops::Mul;
 use frame_support::traits::{fungibles::Inspect, OnInitialize};
@@ -93,7 +93,7 @@ fn make_new_simple_offer(
 	token_id: TokenId,
 	buyer: AccountId,
 	marketplace_id: Option<MarketplaceId>,
-) -> (OfferId, SimpleOffer<AccountId>) {
+) -> (OfferId, SimpleOffer<Test>) {
 	let next_offer_id = NextOfferId::<Test>::get();
 
 	assert_ok!(Marketplace::make_simple_offer(
@@ -109,6 +109,7 @@ fn make_new_simple_offer(
 		amount: offer_amount,
 		buyer,
 		marketplace_id,
+		expires_at: System::block_number() + DefaultOfferDuration::get(),
 	};
 
 	// Check storage has been updated
@@ -2734,6 +2735,7 @@ fn remove_offer() {
 				offer_id,
 				marketplace_id: None,
 				token_id,
+				reason: OfferRemovalReason::SellerRemoved,
 			}));
 
 			// Check storage has been removed
@@ -2774,6 +2776,7 @@ fn remove_offer_multiple_offers() {
 				offer_id: offer_id_1,
 				marketplace_id: None,
 				token_id,
+				reason: OfferRemovalReason::SellerRemoved,
 			}));
 
 			// Check that only the first offer is removed

--- a/pallet/marketplace/src/tests.rs
+++ b/pallet/marketplace/src/tests.rs
@@ -2870,7 +2870,7 @@ fn remove_offers_empty_vector_should_succeed() {
 fn remove_offers_mixed_valid_invalid_should_fail() {
 	let buyer = create_account(5);
 	let initial_balance_buyer = 1000;
-	
+
 	TestExt::<Test>::default()
 		.with_balances(&[(buyer, initial_balance_buyer)])
 		.build()
@@ -2900,7 +2900,7 @@ fn remove_offers_mixed_valid_invalid_should_fail() {
 fn remove_offers_wrong_token_should_fail() {
 	let buyer = create_account(5);
 	let initial_balance_buyer = 1000;
-	
+
 	TestExt::<Test>::default()
 		.with_balances(&[(buyer, initial_balance_buyer)])
 		.build()

--- a/pallet/marketplace/src/tests.rs
+++ b/pallet/marketplace/src/tests.rs
@@ -103,13 +103,15 @@ fn make_new_simple_offer(
 		NativeAssetId::get(),
 		marketplace_id
 	));
+
+	let close = System::block_number() + DefaultOfferDuration::get();
 	let offer = SimpleOffer {
 		token_id,
 		asset_id: NativeAssetId::get(),
 		amount: offer_amount,
 		buyer,
 		marketplace_id,
-		expires_at: System::block_number() + DefaultOfferDuration::get(),
+		close,
 	};
 
 	// Check storage has been updated
@@ -121,6 +123,7 @@ fn make_new_simple_offer(
 		asset_id: NativeAssetId::get(),
 		marketplace_id,
 		buyer,
+		close,
 	}));
 
 	(next_offer_id, offer)

--- a/pallet/marketplace/src/types.rs
+++ b/pallet/marketplace/src/types.rs
@@ -192,12 +192,18 @@ impl<T: Config> ListingTokens<T> {
 #[derive(Decode, Encode, Debug, Clone, PartialEq, TypeInfo, MaxEncodedLen)]
 #[scale_info(skip_type_params(T))]
 pub struct SimpleOffer<T: Config> {
+	/// The token being offered on
 	pub token_id: TokenId,
+	/// The asset being used for the offer
 	pub asset_id: AssetId,
+	/// The amount being offered
 	pub amount: Balance,
+	/// The account making the offer
 	pub buyer: T::AccountId,
+	/// The marketplace this offer was made on, if any
 	pub marketplace_id: Option<MarketplaceId>,
-	pub expires_at: BlockNumberFor<T>,
+	/// When the offer closes
+	pub close: BlockNumberFor<T>,
 }
 
 #[derive(Decode, Encode, Debug, Clone, PartialEq, TypeInfo, MaxEncodedLen)]

--- a/pallet/marketplace/src/types.rs
+++ b/pallet/marketplace/src/types.rs
@@ -190,18 +190,20 @@ impl<T: Config> ListingTokens<T> {
 
 /// Holds information relating to NFT offers
 #[derive(Decode, Encode, Debug, Clone, PartialEq, TypeInfo, MaxEncodedLen)]
-pub struct SimpleOffer<AccountId> {
+#[scale_info(skip_type_params(T))]
+pub struct SimpleOffer<T: Config> {
 	pub token_id: TokenId,
 	pub asset_id: AssetId,
 	pub amount: Balance,
-	pub buyer: AccountId,
+	pub buyer: T::AccountId,
 	pub marketplace_id: Option<MarketplaceId>,
+	pub expires_at: BlockNumberFor<T>,
 }
 
 #[derive(Decode, Encode, Debug, Clone, PartialEq, TypeInfo, MaxEncodedLen)]
-#[codec(mel_bound(AccountId: MaxEncodedLen))]
-pub enum OfferType<AccountId> {
-	Simple(SimpleOffer<AccountId>),
+#[scale_info(skip_type_params(T))]
+pub enum OfferType<T: Config> {
+	Simple(SimpleOffer<T>),
 }
 
 /// Reasons for an auction closure
@@ -224,6 +226,15 @@ pub enum FixedPriceClosureReason {
 	Expired,
 	/// Vendor accepted a buy offer
 	OfferAccepted,
+}
+
+/// Reason for an offer removal
+#[derive(Decode, Encode, Debug, Clone, PartialEq, TypeInfo)]
+pub enum OfferRemovalReason {
+	/// Offer was manually removed by the token owner
+	SellerRemoved,
+	/// Offer expired automatically
+	Expired,
 }
 
 /// Information about a marketplace

--- a/pallet/marketplace/src/weights.rs
+++ b/pallet/marketplace/src/weights.rs
@@ -60,6 +60,7 @@ pub trait WeightInfo {
 	fn make_simple_offer() -> Weight;
 	fn cancel_offer() -> Weight;
 	fn accept_offer() -> Weight;
+   fn remove_offer() -> Weight; 
 	fn set_fee_to() -> Weight;
 }
 
@@ -319,6 +320,30 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 		Weight::from_all(325_816_000_u64)
 			.saturating_add(T::DbWeight::get().reads(10_u64))
 			.saturating_add(T::DbWeight::get().writes(10_u64))
+	}
+	/// Storage: `Marketplace::Offers` (r:1 w:1)
+	/// Proof: `Marketplace::Offers` (`max_values`: None, `max_size`: Some(70), added: 2545, mode: `MaxEncodedLen`)
+	/// Storage: `Nft::TokenInfo` (r:1 w:0)
+	/// Proof: `Nft::TokenInfo` (`max_values`: None, `max_size`: Some(65), added: 2540, mode: `MaxEncodedLen`)
+	/// Storage: `AssetsExt::Holds` (r:1 w:1)
+	/// Proof: `AssetsExt::Holds` (`max_values`: None, `max_size`: Some(433), added: 2908, mode: `MaxEncodedLen`)
+	/// Storage: `Assets::Asset` (r:1 w:1)
+	/// Proof: `Assets::Asset` (`max_values`: None, `max_size`: Some(162), added: 2637, mode: `MaxEncodedLen`)
+	/// Storage: `Assets::Account` (r:2 w:2)
+	/// Proof: `Assets::Account` (`max_values`: None, `max_size`: Some(110), added: 2585, mode: `MaxEncodedLen`)
+	/// Storage: `System::Account` (r:1 w:1)
+	/// Proof: `System::Account` (`max_values`: None, `max_size`: Some(116), added: 2591, mode: `MaxEncodedLen`)
+	/// Storage: `Marketplace::TokenOffers` (r:1 w:1)
+	/// Proof: `Marketplace::TokenOffers` (`max_values`: None, `max_size`: Some(818), added: 3293, mode: `MaxEncodedLen`)
+	fn remove_offer() -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `2512`
+		//  Estimated: `6160`
+		// Minimum execution time: 94_000_000 picoseconds.
+		Weight::from_parts(96_000_000, 0)
+			.saturating_add(Weight::from_parts(0, 6160))
+			.saturating_add(T::DbWeight::get().reads(8))
+			.saturating_add(T::DbWeight::get().writes(7))
 	}
 	// Storage: `Marketplace::FeeTo` (r:0 w:1)
 	// Proof: `Marketplace::FeeTo` (`max_values`: Some(1), `max_size`: Some(21), added: 516, mode: `MaxEncodedLen`)
@@ -583,6 +608,30 @@ impl WeightInfo for () {
 		Weight::from_all(325_816_000_u64)
 			.saturating_add(RocksDbWeight::get().reads(10_u64))
 			.saturating_add(RocksDbWeight::get().writes(10_u64))
+	}
+	/// Storage: `Marketplace::Offers` (r:1 w:1)
+	/// Proof: `Marketplace::Offers` (`max_values`: None, `max_size`: Some(70), added: 2545, mode: `MaxEncodedLen`)
+	/// Storage: `Nft::TokenInfo` (r:1 w:0)
+	/// Proof: `Nft::TokenInfo` (`max_values`: None, `max_size`: Some(65), added: 2540, mode: `MaxEncodedLen`)
+	/// Storage: `AssetsExt::Holds` (r:1 w:1)
+	/// Proof: `AssetsExt::Holds` (`max_values`: None, `max_size`: Some(433), added: 2908, mode: `MaxEncodedLen`)
+	/// Storage: `Assets::Asset` (r:1 w:1)
+	/// Proof: `Assets::Asset` (`max_values`: None, `max_size`: Some(162), added: 2637, mode: `MaxEncodedLen`)
+	/// Storage: `Assets::Account` (r:2 w:2)
+	/// Proof: `Assets::Account` (`max_values`: None, `max_size`: Some(110), added: 2585, mode: `MaxEncodedLen`)
+	/// Storage: `System::Account` (r:1 w:1)
+	/// Proof: `System::Account` (`max_values`: None, `max_size`: Some(116), added: 2591, mode: `MaxEncodedLen`)
+	/// Storage: `Marketplace::TokenOffers` (r:1 w:1)
+	/// Proof: `Marketplace::TokenOffers` (`max_values`: None, `max_size`: Some(818), added: 3293, mode: `MaxEncodedLen`)
+	fn remove_offer() -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `2512`
+		//  Estimated: `6160`
+		// Minimum execution time: 94_000_000 picoseconds.
+		Weight::from_parts(96_000_000, 0)
+			.saturating_add(Weight::from_parts(0, 6160))
+			.saturating_add(RocksDbWeight::get().reads(8))
+			.saturating_add(RocksDbWeight::get().writes(7))
 	}
 	// Storage: `Marketplace::FeeTo` (r:0 w:1)
 	// Proof: `Marketplace::FeeTo` (`max_values`: Some(1), `max_size`: Some(21), added: 516, mode: `MaxEncodedLen`)

--- a/pallet/marketplace/src/weights.rs
+++ b/pallet/marketplace/src/weights.rs
@@ -60,8 +60,9 @@ pub trait WeightInfo {
 	fn make_simple_offer() -> Weight;
 	fn cancel_offer() -> Weight;
 	fn accept_offer() -> Weight;
-   fn remove_offer() -> Weight; 
 	fn set_fee_to() -> Weight;
+   fn make_simple_offer_with_duration() -> Weight;
+   fn remove_offers(p: u32, ) -> Weight;
 }
 
 /// Weights for pallet_marketplace using the Substrate node and recommended hardware.
@@ -321,10 +322,16 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 			.saturating_add(T::DbWeight::get().reads(10_u64))
 			.saturating_add(T::DbWeight::get().writes(10_u64))
 	}
-	/// Storage: `Marketplace::Offers` (r:1 w:1)
-	/// Proof: `Marketplace::Offers` (`max_values`: None, `max_size`: Some(70), added: 2545, mode: `MaxEncodedLen`)
+	// Storage: `Marketplace::FeeTo` (r:0 w:1)
+	// Proof: `Marketplace::FeeTo` (`max_values`: Some(1), `max_size`: Some(21), added: 516, mode: `MaxEncodedLen`)
+	fn set_fee_to() -> Weight {
+		Weight::from_all(24_729_000_u64)
+			.saturating_add(T::DbWeight::get().writes(1_u64))
+	}
 	/// Storage: `Nft::TokenInfo` (r:1 w:0)
 	/// Proof: `Nft::TokenInfo` (`max_values`: None, `max_size`: Some(65), added: 2540, mode: `MaxEncodedLen`)
+	/// Storage: `Marketplace::NextOfferId` (r:1 w:1)
+	/// Proof: `Marketplace::NextOfferId` (`max_values`: Some(1), `max_size`: Some(8), added: 503, mode: `MaxEncodedLen`)
 	/// Storage: `AssetsExt::Holds` (r:1 w:1)
 	/// Proof: `AssetsExt::Holds` (`max_values`: None, `max_size`: Some(433), added: 2908, mode: `MaxEncodedLen`)
 	/// Storage: `Assets::Asset` (r:1 w:1)
@@ -335,21 +342,51 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	/// Proof: `System::Account` (`max_values`: None, `max_size`: Some(116), added: 2591, mode: `MaxEncodedLen`)
 	/// Storage: `Marketplace::TokenOffers` (r:1 w:1)
 	/// Proof: `Marketplace::TokenOffers` (`max_values`: None, `max_size`: Some(818), added: 3293, mode: `MaxEncodedLen`)
-	fn remove_offer() -> Weight {
+	/// Storage: `Marketplace::Offers` (r:0 w:1)
+	/// Proof: `Marketplace::Offers` (`max_values`: None, `max_size`: Some(74), added: 2549, mode: `MaxEncodedLen`)
+	/// Storage: `Marketplace::OfferEndSchedule` (r:0 w:1)
+	/// Proof: `Marketplace::OfferEndSchedule` (`max_values`: None, `max_size`: Some(29), added: 2504, mode: `MaxEncodedLen`)
+	fn make_simple_offer_with_duration() -> Weight {
 		// Proof Size summary in bytes:
-		//  Measured:  `2512`
+		//  Measured:  `2131`
 		//  Estimated: `6160`
-		// Minimum execution time: 94_000_000 picoseconds.
-		Weight::from_parts(96_000_000, 0)
+		// Minimum execution time: 92_000_000 picoseconds.
+		Weight::from_parts(103_000_000, 0)
 			.saturating_add(Weight::from_parts(0, 6160))
 			.saturating_add(T::DbWeight::get().reads(8))
-			.saturating_add(T::DbWeight::get().writes(7))
+			.saturating_add(T::DbWeight::get().writes(9))
 	}
-	// Storage: `Marketplace::FeeTo` (r:0 w:1)
-	// Proof: `Marketplace::FeeTo` (`max_values`: Some(1), `max_size`: Some(21), added: 516, mode: `MaxEncodedLen`)
-	fn set_fee_to() -> Weight {
-		Weight::from_all(24_729_000_u64)
-			.saturating_add(T::DbWeight::get().writes(1_u64))
+	/// Storage: `Nft::TokenInfo` (r:1 w:0)
+	/// Proof: `Nft::TokenInfo` (`max_values`: None, `max_size`: Some(65), added: 2540, mode: `MaxEncodedLen`)
+	/// Storage: `Marketplace::TokenOffers` (r:1 w:1)
+	/// Proof: `Marketplace::TokenOffers` (`max_values`: None, `max_size`: Some(818), added: 3293, mode: `MaxEncodedLen`)
+	/// Storage: `Marketplace::Offers` (r:10 w:10)
+	/// Proof: `Marketplace::Offers` (`max_values`: None, `max_size`: Some(74), added: 2549, mode: `MaxEncodedLen`)
+	/// Storage: `AssetsExt::Holds` (r:10 w:10)
+	/// Proof: `AssetsExt::Holds` (`max_values`: None, `max_size`: Some(433), added: 2908, mode: `MaxEncodedLen`)
+	/// Storage: `Assets::Asset` (r:10 w:10)
+	/// Proof: `Assets::Asset` (`max_values`: None, `max_size`: Some(162), added: 2637, mode: `MaxEncodedLen`)
+	/// Storage: `Assets::Account` (r:20 w:20)
+	/// Proof: `Assets::Account` (`max_values`: None, `max_size`: Some(110), added: 2585, mode: `MaxEncodedLen`)
+	/// Storage: `System::Account` (r:1 w:1)
+	/// Proof: `System::Account` (`max_values`: None, `max_size`: Some(116), added: 2591, mode: `MaxEncodedLen`)
+	/// Storage: `Marketplace::OfferEndSchedule` (r:0 w:10)
+	/// Proof: `Marketplace::OfferEndSchedule` (`max_values`: None, `max_size`: Some(29), added: 2504, mode: `MaxEncodedLen`)
+	/// The range of component `p` is `[1, 10]`.
+	fn remove_offers(p: u32, ) -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `2065 + p * (516 ±0)`
+		//  Estimated: `4283 + p * (5170 ±0)`
+		// Minimum execution time: 95_000_000 picoseconds.
+		Weight::from_parts(52_475_368, 0)
+			.saturating_add(Weight::from_parts(0, 4283))
+			// Standard Error: 64_686
+			.saturating_add(Weight::from_parts(51_623_233, 0).saturating_mul(p.into()))
+			.saturating_add(T::DbWeight::get().reads(3))
+			.saturating_add(T::DbWeight::get().reads((5_u64).saturating_mul(p.into())))
+			.saturating_add(T::DbWeight::get().writes(2))
+			.saturating_add(T::DbWeight::get().writes((6_u64).saturating_mul(p.into())))
+			.saturating_add(Weight::from_parts(0, 5170).saturating_mul(p.into()))
 	}
 }
 
@@ -609,10 +646,16 @@ impl WeightInfo for () {
 			.saturating_add(RocksDbWeight::get().reads(10_u64))
 			.saturating_add(RocksDbWeight::get().writes(10_u64))
 	}
-	/// Storage: `Marketplace::Offers` (r:1 w:1)
-	/// Proof: `Marketplace::Offers` (`max_values`: None, `max_size`: Some(70), added: 2545, mode: `MaxEncodedLen`)
+	// Storage: `Marketplace::FeeTo` (r:0 w:1)
+	// Proof: `Marketplace::FeeTo` (`max_values`: Some(1), `max_size`: Some(21), added: 516, mode: `MaxEncodedLen`)
+	fn set_fee_to() -> Weight {
+		Weight::from_all(24_729_000_u64)
+			.saturating_add(RocksDbWeight::get().writes(1_u64))
+	}
 	/// Storage: `Nft::TokenInfo` (r:1 w:0)
 	/// Proof: `Nft::TokenInfo` (`max_values`: None, `max_size`: Some(65), added: 2540, mode: `MaxEncodedLen`)
+	/// Storage: `Marketplace::NextOfferId` (r:1 w:1)
+	/// Proof: `Marketplace::NextOfferId` (`max_values`: Some(1), `max_size`: Some(8), added: 503, mode: `MaxEncodedLen`)
 	/// Storage: `AssetsExt::Holds` (r:1 w:1)
 	/// Proof: `AssetsExt::Holds` (`max_values`: None, `max_size`: Some(433), added: 2908, mode: `MaxEncodedLen`)
 	/// Storage: `Assets::Asset` (r:1 w:1)
@@ -623,21 +666,51 @@ impl WeightInfo for () {
 	/// Proof: `System::Account` (`max_values`: None, `max_size`: Some(116), added: 2591, mode: `MaxEncodedLen`)
 	/// Storage: `Marketplace::TokenOffers` (r:1 w:1)
 	/// Proof: `Marketplace::TokenOffers` (`max_values`: None, `max_size`: Some(818), added: 3293, mode: `MaxEncodedLen`)
-	fn remove_offer() -> Weight {
+	/// Storage: `Marketplace::Offers` (r:0 w:1)
+	/// Proof: `Marketplace::Offers` (`max_values`: None, `max_size`: Some(74), added: 2549, mode: `MaxEncodedLen`)
+	/// Storage: `Marketplace::OfferEndSchedule` (r:0 w:1)
+	/// Proof: `Marketplace::OfferEndSchedule` (`max_values`: None, `max_size`: Some(29), added: 2504, mode: `MaxEncodedLen`)
+	fn make_simple_offer_with_duration() -> Weight {
 		// Proof Size summary in bytes:
-		//  Measured:  `2512`
+		//  Measured:  `2131`
 		//  Estimated: `6160`
-		// Minimum execution time: 94_000_000 picoseconds.
-		Weight::from_parts(96_000_000, 0)
+		// Minimum execution time: 92_000_000 picoseconds.
+		Weight::from_parts(103_000_000, 0)
 			.saturating_add(Weight::from_parts(0, 6160))
 			.saturating_add(RocksDbWeight::get().reads(8))
-			.saturating_add(RocksDbWeight::get().writes(7))
+			.saturating_add(RocksDbWeight::get().writes(9))
 	}
-	// Storage: `Marketplace::FeeTo` (r:0 w:1)
-	// Proof: `Marketplace::FeeTo` (`max_values`: Some(1), `max_size`: Some(21), added: 516, mode: `MaxEncodedLen`)
-	fn set_fee_to() -> Weight {
-		Weight::from_all(24_729_000_u64)
-			.saturating_add(RocksDbWeight::get().writes(1_u64))
+	/// Storage: `Nft::TokenInfo` (r:1 w:0)
+	/// Proof: `Nft::TokenInfo` (`max_values`: None, `max_size`: Some(65), added: 2540, mode: `MaxEncodedLen`)
+	/// Storage: `Marketplace::TokenOffers` (r:1 w:1)
+	/// Proof: `Marketplace::TokenOffers` (`max_values`: None, `max_size`: Some(818), added: 3293, mode: `MaxEncodedLen`)
+	/// Storage: `Marketplace::Offers` (r:10 w:10)
+	/// Proof: `Marketplace::Offers` (`max_values`: None, `max_size`: Some(74), added: 2549, mode: `MaxEncodedLen`)
+	/// Storage: `AssetsExt::Holds` (r:10 w:10)
+	/// Proof: `AssetsExt::Holds` (`max_values`: None, `max_size`: Some(433), added: 2908, mode: `MaxEncodedLen`)
+	/// Storage: `Assets::Asset` (r:10 w:10)
+	/// Proof: `Assets::Asset` (`max_values`: None, `max_size`: Some(162), added: 2637, mode: `MaxEncodedLen`)
+	/// Storage: `Assets::Account` (r:20 w:20)
+	/// Proof: `Assets::Account` (`max_values`: None, `max_size`: Some(110), added: 2585, mode: `MaxEncodedLen`)
+	/// Storage: `System::Account` (r:1 w:1)
+	/// Proof: `System::Account` (`max_values`: None, `max_size`: Some(116), added: 2591, mode: `MaxEncodedLen`)
+	/// Storage: `Marketplace::OfferEndSchedule` (r:0 w:10)
+	/// Proof: `Marketplace::OfferEndSchedule` (`max_values`: None, `max_size`: Some(29), added: 2504, mode: `MaxEncodedLen`)
+	/// The range of component `p` is `[1, 10]`.
+	fn remove_offers(p: u32, ) -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `2065 + p * (516 ±0)`
+		//  Estimated: `4283 + p * (5170 ±0)`
+		// Minimum execution time: 95_000_000 picoseconds.
+		Weight::from_parts(52_475_368, 0)
+			.saturating_add(Weight::from_parts(0, 4283))
+			// Standard Error: 64_686
+			.saturating_add(Weight::from_parts(51_623_233, 0).saturating_mul(p.into()))
+			.saturating_add(RocksDbWeight::get().reads(3))
+			.saturating_add(RocksDbWeight::get().reads((5_u64).saturating_mul(p.into())))
+			.saturating_add(RocksDbWeight::get().writes(2))
+			.saturating_add(RocksDbWeight::get().writes((6_u64).saturating_mul(p.into())))
+			.saturating_add(Weight::from_parts(0, 5170).saturating_mul(p.into()))
 	}
 }
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -507,6 +507,8 @@ parameter_types! {
 	pub const MarketplacePalletId: PalletId = PalletId(*b"marketpl");
 	/// How long listings are open for by default
 	pub const DefaultListingDuration: BlockNumber = DAYS * 3;
+	/// How long offers are valid for by default
+	pub const DefaultOfferDuration: BlockNumber = DAYS * 30;
 	pub const MaxTokensPerListing: u32 = 1000;
 	pub const MaxListingsPerMultiBuy: u32 = 50;
 	pub const MaxOffers: u32 = 100;
@@ -516,6 +518,7 @@ parameter_types! {
 impl pallet_marketplace::Config for Runtime {
 	type RuntimeCall = RuntimeCall;
 	type DefaultListingDuration = DefaultListingDuration;
+	type DefaultOfferDuration = DefaultOfferDuration;
 	type RuntimeEvent = RuntimeEvent;
 	type DefaultFeeTo = DefaultFeeTo;
 	type MultiCurrency = AssetsExt;

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -512,6 +512,7 @@ parameter_types! {
 	pub const MaxTokensPerListing: u32 = 1000;
 	pub const MaxListingsPerMultiBuy: u32 = 50;
 	pub const MaxOffers: u32 = 100;
+	pub const MaxRemovableOffers: u32 = 10;
 	pub const MarketplaceNetworkFeePercentage: Permill = Permill::from_perthousand(5);
 	pub const DefaultTxFeePotId: Option<PalletId> = Some(TxFeePotId::get());
 }
@@ -530,6 +531,7 @@ impl pallet_marketplace::Config for Runtime {
 	type MaxTokensPerListing = MaxTokensPerListing;
 	type MaxListingsPerMultiBuy = MaxListingsPerMultiBuy;
 	type MaxOffers = MaxOffers;
+	type MaxRemovableOffers = MaxRemovableOffers;
 }
 
 parameter_types! {

--- a/runtime/src/weights/pallet_marketplace.rs
+++ b/runtime/src/weights/pallet_marketplace.rs
@@ -357,6 +357,30 @@ impl<T: frame_system::Config> pallet_marketplace::WeightInfo for WeightInfo<T> {
 			.saturating_add(T::DbWeight::get().reads(10))
 			.saturating_add(T::DbWeight::get().writes(10))
 	}
+	/// Storage: `Marketplace::Offers` (r:1 w:1)
+	/// Proof: `Marketplace::Offers` (`max_values`: None, `max_size`: Some(70), added: 2545, mode: `MaxEncodedLen`)
+	/// Storage: `Nft::TokenInfo` (r:1 w:0)
+	/// Proof: `Nft::TokenInfo` (`max_values`: None, `max_size`: Some(65), added: 2540, mode: `MaxEncodedLen`)
+	/// Storage: `AssetsExt::Holds` (r:1 w:1)
+	/// Proof: `AssetsExt::Holds` (`max_values`: None, `max_size`: Some(433), added: 2908, mode: `MaxEncodedLen`)
+	/// Storage: `Assets::Asset` (r:1 w:1)
+	/// Proof: `Assets::Asset` (`max_values`: None, `max_size`: Some(162), added: 2637, mode: `MaxEncodedLen`)
+	/// Storage: `Assets::Account` (r:2 w:2)
+	/// Proof: `Assets::Account` (`max_values`: None, `max_size`: Some(110), added: 2585, mode: `MaxEncodedLen`)
+	/// Storage: `System::Account` (r:1 w:1)
+	/// Proof: `System::Account` (`max_values`: None, `max_size`: Some(116), added: 2591, mode: `MaxEncodedLen`)
+	/// Storage: `Marketplace::TokenOffers` (r:1 w:1)
+	/// Proof: `Marketplace::TokenOffers` (`max_values`: None, `max_size`: Some(818), added: 3293, mode: `MaxEncodedLen`)
+	fn remove_offer() -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `2512`
+		//  Estimated: `6160`
+		// Minimum execution time: 94_000_000 picoseconds.
+		Weight::from_parts(96_000_000, 0)
+			.saturating_add(Weight::from_parts(0, 6160))
+			.saturating_add(T::DbWeight::get().reads(8))
+			.saturating_add(T::DbWeight::get().writes(7))
+	}
 	/// Storage: `Marketplace::FeeTo` (r:0 w:1)
 	/// Proof: `Marketplace::FeeTo` (`max_values`: Some(1), `max_size`: Some(21), added: 516, mode: `MaxEncodedLen`)
 	fn set_fee_to() -> Weight {

--- a/runtime/src/weights/pallet_marketplace.rs
+++ b/runtime/src/weights/pallet_marketplace.rs
@@ -357,30 +357,6 @@ impl<T: frame_system::Config> pallet_marketplace::WeightInfo for WeightInfo<T> {
 			.saturating_add(T::DbWeight::get().reads(10))
 			.saturating_add(T::DbWeight::get().writes(10))
 	}
-	/// Storage: `Marketplace::Offers` (r:1 w:1)
-	/// Proof: `Marketplace::Offers` (`max_values`: None, `max_size`: Some(70), added: 2545, mode: `MaxEncodedLen`)
-	/// Storage: `Nft::TokenInfo` (r:1 w:0)
-	/// Proof: `Nft::TokenInfo` (`max_values`: None, `max_size`: Some(65), added: 2540, mode: `MaxEncodedLen`)
-	/// Storage: `AssetsExt::Holds` (r:1 w:1)
-	/// Proof: `AssetsExt::Holds` (`max_values`: None, `max_size`: Some(433), added: 2908, mode: `MaxEncodedLen`)
-	/// Storage: `Assets::Asset` (r:1 w:1)
-	/// Proof: `Assets::Asset` (`max_values`: None, `max_size`: Some(162), added: 2637, mode: `MaxEncodedLen`)
-	/// Storage: `Assets::Account` (r:2 w:2)
-	/// Proof: `Assets::Account` (`max_values`: None, `max_size`: Some(110), added: 2585, mode: `MaxEncodedLen`)
-	/// Storage: `System::Account` (r:1 w:1)
-	/// Proof: `System::Account` (`max_values`: None, `max_size`: Some(116), added: 2591, mode: `MaxEncodedLen`)
-	/// Storage: `Marketplace::TokenOffers` (r:1 w:1)
-	/// Proof: `Marketplace::TokenOffers` (`max_values`: None, `max_size`: Some(818), added: 3293, mode: `MaxEncodedLen`)
-	fn remove_offer() -> Weight {
-		// Proof Size summary in bytes:
-		//  Measured:  `2512`
-		//  Estimated: `6160`
-		// Minimum execution time: 94_000_000 picoseconds.
-		Weight::from_parts(96_000_000, 0)
-			.saturating_add(Weight::from_parts(0, 6160))
-			.saturating_add(T::DbWeight::get().reads(8))
-			.saturating_add(T::DbWeight::get().writes(7))
-	}
 	/// Storage: `Marketplace::FeeTo` (r:0 w:1)
 	/// Proof: `Marketplace::FeeTo` (`max_values`: Some(1), `max_size`: Some(21), added: 516, mode: `MaxEncodedLen`)
 	fn set_fee_to() -> Weight {
@@ -391,5 +367,65 @@ impl<T: frame_system::Config> pallet_marketplace::WeightInfo for WeightInfo<T> {
 		Weight::from_parts(25_172_000, 0)
 			.saturating_add(Weight::from_parts(0, 0))
 			.saturating_add(T::DbWeight::get().writes(1))
+	}
+	/// Storage: `Nft::TokenInfo` (r:1 w:0)
+	/// Proof: `Nft::TokenInfo` (`max_values`: None, `max_size`: Some(65), added: 2540, mode: `MaxEncodedLen`)
+	/// Storage: `Marketplace::NextOfferId` (r:1 w:1)
+	/// Proof: `Marketplace::NextOfferId` (`max_values`: Some(1), `max_size`: Some(8), added: 503, mode: `MaxEncodedLen`)
+	/// Storage: `AssetsExt::Holds` (r:1 w:1)
+	/// Proof: `AssetsExt::Holds` (`max_values`: None, `max_size`: Some(433), added: 2908, mode: `MaxEncodedLen`)
+	/// Storage: `Assets::Asset` (r:1 w:1)
+	/// Proof: `Assets::Asset` (`max_values`: None, `max_size`: Some(162), added: 2637, mode: `MaxEncodedLen`)
+	/// Storage: `Assets::Account` (r:2 w:2)
+	/// Proof: `Assets::Account` (`max_values`: None, `max_size`: Some(110), added: 2585, mode: `MaxEncodedLen`)
+	/// Storage: `System::Account` (r:1 w:1)
+	/// Proof: `System::Account` (`max_values`: None, `max_size`: Some(116), added: 2591, mode: `MaxEncodedLen`)
+	/// Storage: `Marketplace::TokenOffers` (r:1 w:1)
+	/// Proof: `Marketplace::TokenOffers` (`max_values`: None, `max_size`: Some(818), added: 3293, mode: `MaxEncodedLen`)
+	/// Storage: `Marketplace::Offers` (r:0 w:1)
+	/// Proof: `Marketplace::Offers` (`max_values`: None, `max_size`: Some(74), added: 2549, mode: `MaxEncodedLen`)
+	/// Storage: `Marketplace::OfferEndSchedule` (r:0 w:1)
+	/// Proof: `Marketplace::OfferEndSchedule` (`max_values`: None, `max_size`: Some(29), added: 2504, mode: `MaxEncodedLen`)
+	fn make_simple_offer_with_duration() -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `2131`
+		//  Estimated: `6160`
+		// Minimum execution time: 92_000_000 picoseconds.
+		Weight::from_parts(103_000_000, 0)
+			.saturating_add(Weight::from_parts(0, 6160))
+			.saturating_add(T::DbWeight::get().reads(8))
+			.saturating_add(T::DbWeight::get().writes(9))
+	}
+	/// Storage: `Nft::TokenInfo` (r:1 w:0)
+	/// Proof: `Nft::TokenInfo` (`max_values`: None, `max_size`: Some(65), added: 2540, mode: `MaxEncodedLen`)
+	/// Storage: `Marketplace::TokenOffers` (r:1 w:1)
+	/// Proof: `Marketplace::TokenOffers` (`max_values`: None, `max_size`: Some(818), added: 3293, mode: `MaxEncodedLen`)
+	/// Storage: `Marketplace::Offers` (r:10 w:10)
+	/// Proof: `Marketplace::Offers` (`max_values`: None, `max_size`: Some(74), added: 2549, mode: `MaxEncodedLen`)
+	/// Storage: `AssetsExt::Holds` (r:10 w:10)
+	/// Proof: `AssetsExt::Holds` (`max_values`: None, `max_size`: Some(433), added: 2908, mode: `MaxEncodedLen`)
+	/// Storage: `Assets::Asset` (r:10 w:10)
+	/// Proof: `Assets::Asset` (`max_values`: None, `max_size`: Some(162), added: 2637, mode: `MaxEncodedLen`)
+	/// Storage: `Assets::Account` (r:20 w:20)
+	/// Proof: `Assets::Account` (`max_values`: None, `max_size`: Some(110), added: 2585, mode: `MaxEncodedLen`)
+	/// Storage: `System::Account` (r:1 w:1)
+	/// Proof: `System::Account` (`max_values`: None, `max_size`: Some(116), added: 2591, mode: `MaxEncodedLen`)
+	/// Storage: `Marketplace::OfferEndSchedule` (r:0 w:10)
+	/// Proof: `Marketplace::OfferEndSchedule` (`max_values`: None, `max_size`: Some(29), added: 2504, mode: `MaxEncodedLen`)
+	/// The range of component `p` is `[1, 10]`.
+	fn remove_offers(p: u32, ) -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `2065 + p * (516 ±0)`
+		//  Estimated: `4283 + p * (5170 ±0)`
+		// Minimum execution time: 95_000_000 picoseconds.
+		Weight::from_parts(52_475_368, 0)
+			.saturating_add(Weight::from_parts(0, 4283))
+			// Standard Error: 64_686
+			.saturating_add(Weight::from_parts(51_623_233, 0).saturating_mul(p.into()))
+			.saturating_add(T::DbWeight::get().reads(3))
+			.saturating_add(T::DbWeight::get().reads((5_u64).saturating_mul(p.into())))
+			.saturating_add(T::DbWeight::get().writes(2))
+			.saturating_add(T::DbWeight::get().writes((6_u64).saturating_mul(p.into())))
+			.saturating_add(Weight::from_parts(0, 5170).saturating_mul(p.into()))
 	}
 }


### PR DESCRIPTION
# Description

 - Updates `SimpleOffer` with `close` to allow for expiry of offers
 - New extrinsic `make_simple_offer_with_duration` to enable users to set a custom duration for their offer
 - New extrinsic `remove_offers` that allows a listing owner to remove offers on their listing
 - New function `close_offers_at` that cleans up expired listings in `on_initialize`
 - NOTE: some decisions were changed since the RFC, but much of this is still relevant, leaving as draft for now

## Context & Background

 - https://www.notion.so/futureverse/RFC-Marketplace-Offer-Issue-2650cb4dab3d80be96e0d74af477aa85?utm_content=2650cb4d-ab3d-80be-96e0-d74af477aa85&utm_campaign=T03JUCB2G03&pvs=6

## Notes & Additional Information

 - Adds expiry to simple marketplace offers and enables direct removal of offers by listing owners

# Release Notes

## Key Changes

## Type of Change

- [x] Runtime Changes
- [ ] Client Changes

## API Changes

### EVM Precompile Changes

#### Added

 - Marketplace: `makeSimpleOfferWithDuration`
 - Marketplace: `removeOffers`

### Storage Changes

#### Changed

 - Marketplace: Added `close` to `SimpleOffer`

### Extrinsic Changes

#### Added

 - Marketplace: `make_simple_offer_with_duration`
 - Marketplace: `remove_offers`

### Event Changes

#### Added

- Marketplace: OffersRemove

#### Changed

- Marketplace: Offer
